### PR TITLE
Add max value inputs for Long and Double content types #226

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,29 @@
+# app-features
+
+## Build
+
+Run `./gradlew build` to build the project.
+
+## Git & GitHub
+
+No conventional commit prefixes. Plain descriptive language throughout.
+
+### Commits
+
+- **With issue**: use `<Issue Title> #<number>` — e.g. issue `Do fix` #10 becomes `Do fix #10`
+- **Without issue**: capitalized plain-English description — e.g. `Fix build`
+- **Body** (optional): past tense, one line per change, 2–6 lines, backticks for code refs
+
+### Pull Requests
+
+- **Title**: use the exact same pattern as the commit title when linked to an issue (`<Issue Title> #<number>`)
+- **Body**: concisely explain what and why, skip trivial details. No emojis. Separate all sections with one blank line.
+  ```
+  <summary of changes>
+
+  Closes #<number>
+
+  [Claude Code session](<link>)  ← optional
+
+  <sub>*Drafted with AI assistance*</sub>
+  ```

--- a/src/main/resources/cms/content-types/double/double.yaml
+++ b/src/main/resources/cms/content-types/double/double.yaml
@@ -19,3 +19,12 @@ form:
     occurrences:
       min: 1
       max: 0
+  - type: "Double"
+    name: "doubleWithMax"
+    label: "Double with Max Value"
+    helpText: "Required double input with min 1 and max 10"
+    occurrences:
+      min: 1
+      max: 1
+    min: 1
+    max: 10

--- a/src/main/resources/cms/content-types/long/long.yaml
+++ b/src/main/resources/cms/content-types/long/long.yaml
@@ -19,3 +19,12 @@ form:
     occurrences:
       min: 1
       max: 0
+  - type: "Long"
+    name: "longWithMax"
+    label: "Long with Max Value"
+    helpText: "Required long input with min 1 and max 10"
+    occurrences:
+      min: 1
+      max: 1
+    min: 1
+    max: 10


### PR DESCRIPTION
## Changes

- Added `longWithMax` field to Long content type with min: 1, max: 10
- Added `doubleWithMax` field to Double content type with min: 1, max: 10
- Added CLAUDE.md and AGENTS.md

Closes #226

<sub>*Drafted with AI assistance*</sub>
