### PR TITLE
Bump enonic libs to XP8 SNAPSHOTs

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,8 +1,8 @@
 [versions]
-http-client = "3.2.2"
+http-client = "4.0.0-SNAPSHOT"
 thymeleaf = "3.0.0-SNAPSHOT"
-mustache = "2.1.1"
-text-encoding = "2.1.1"
+mustache = "3.0.0-SNAPSHOT"
+text-encoding = "3.0.0-SNAPSHOT"
 junit-bom = "6.0.3"
 
 [libraries]


### PR DESCRIPTION
## Summary

Bump the remaining enonic-lib deps still pinned to pre-XP8 release versions. Repo already uses `xp.enonicRepo('dev')`, so no repo change needed.

- `lib-http-client` 3.2.2 → 4.0.0-SNAPSHOT
- `lib-mustache` 2.1.1 → 3.0.0-SNAPSHOT
- `lib-text-encoding` 2.1.1 → 3.0.0-SNAPSHOT

## Test plan

- [ ] `./gradlew build --refresh-dependencies` resolves all SNAPSHOTs cleanly and tests pass
- [ ] E2E smoke against XP 8