### PR TITLE
Migrate portal.assetUrl to lib-asset #243

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     include libs.thymeleaf
     include libs.mustache
     include libs.text.encoding
+    include "com.enonic.lib:lib-asset:2.0.0-SNAPSHOT"
     include "com.enonic.xp:lib-sse:${xpVersion}"
 
     testImplementation "com.enonic.xp:testing:${xpVersion}"

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "devDependencies": {
     "@enonic-types/core": "^8.0.0-B4",
     "@enonic-types/global": "^8.0.0-B4",
+    "@enonic-types/lib-asset": "^1.0.3",
     "@enonic-types/lib-auditlog": "^8.0.0-B4",
     "@enonic-types/lib-auth": "^8.0.0-B4",
     "@enonic-types/lib-cluster": "^8.0.0-B4",

--- a/src/main/resources/cms/error/error.ts
+++ b/src/main/resources/cms/error/error.ts
@@ -1,5 +1,6 @@
 import * as thymeleaf from '/lib/thymeleaf';
 import * as portal from '/lib/xp/portal';
+import {assetUrl} from '/lib/enonic/asset';
 import type { ErrorRequest } from '@enonic-types/core';
 
 const view404 = resolve('404.html');
@@ -12,8 +13,8 @@ export const handle404 = function (err: ErrorRequest) {
     }
 
     const params = {
-        cssUrl: portal.assetUrl({path: 'error/css/custom.css'}),
-        imgNotFoundUrl: portal.assetUrl({path: 'error/img/no-nick.svg'}),
+        cssUrl: assetUrl({path: 'error/css/custom.css'}),
+        imgNotFoundUrl: assetUrl({path: 'error/img/no-nick.svg'}),
         siteRootUrl: portal.pageUrl({path: '/features'}),
     };
     const body = thymeleaf.render(view404, params);
@@ -33,8 +34,8 @@ export const handleError = function (err: ErrorRequest) {
 
     const params = {
         errorCode: err.status,
-        cssUrl: portal.assetUrl({path: 'error/css/custom.css'}),
-        imgErrorUrl: portal.assetUrl({path: 'error/img/nick-hanging-from-cloud.svg'}),
+        cssUrl: assetUrl({path: 'error/css/custom.css'}),
+        imgErrorUrl: assetUrl({path: 'error/img/nick-hanging-from-cloud.svg'}),
         siteRootUrl: portal.pageUrl({path: '/features'}),
     };
     const body = thymeleaf.render(viewGeneric, params);

--- a/src/main/resources/cms/layouts/centered/centered.ts
+++ b/src/main/resources/cms/layouts/centered/centered.ts
@@ -1,5 +1,6 @@
 import * as portal from '/lib/xp/portal';
 import * as thymeleaf from '/lib/thymeleaf';
+import {assetUrl} from '/lib/enonic/asset';
 import type {LayoutComponent, Request} from '@enonic-types/core';
 
 export const GET = function (req: Request) {
@@ -8,7 +9,7 @@ export const GET = function (req: Request) {
     return {
         body: thymeleaf.render(resolve('./centered.html'), {
             centerRegion: component.regions["center"],
-            resourcesPath: portal.assetUrl({path: ''}),
+            resourcesPath: assetUrl({path: ''}),
         })
     };
 };

--- a/src/main/resources/cms/layouts/layout-25-75/layout-25-75.ts
+++ b/src/main/resources/cms/layouts/layout-25-75/layout-25-75.ts
@@ -1,5 +1,6 @@
 import * as portal from '/lib/xp/portal';
 import * as thymeleaf from '/lib/thymeleaf';
+import {assetUrl} from '/lib/enonic/asset';
 import type {LayoutComponent, Request} from '@enonic-types/core';
 
 function handleGet(req: Request) {
@@ -14,7 +15,7 @@ function handleGet(req: Request) {
         path: content._path,
         name: content._name,
         editable: editMode,
-        resourcesPath: portal.assetUrl({path: ''}),
+        resourcesPath: assetUrl({path: ''}),
         component: component,
         leftRegion: component.regions["left"],
         rightRegion: component.regions["right"]

--- a/src/main/resources/cms/layouts/layout-3-col/layout-3-col.ts
+++ b/src/main/resources/cms/layouts/layout-3-col/layout-3-col.ts
@@ -1,5 +1,6 @@
 import * as portal from '/lib/xp/portal';
 import * as thymeleaf from '/lib/thymeleaf';
+import {assetUrl} from '/lib/enonic/asset';
 import type {LayoutComponent, Request} from '@enonic-types/core';
 
 export const GET = function (req: Request) {
@@ -14,7 +15,7 @@ export const GET = function (req: Request) {
         path: content._path,
         name: content._name,
         editable: editMode,
-        resourcesPath: portal.assetUrl({path: ''}),
+        resourcesPath: assetUrl({path: ''}),
         component: component,
         leftRegion: component.regions["left"],
         centerRegion: component.regions["center"],

--- a/src/main/resources/cms/layouts/layout-htmlarea/layout-htmlarea.ts
+++ b/src/main/resources/cms/layouts/layout-htmlarea/layout-htmlarea.ts
@@ -1,5 +1,6 @@
 import * as portal from '/lib/xp/portal';
 import * as thymeleaf from '/lib/thymeleaf';
+import {assetUrl} from '/lib/enonic/asset';
 import type {LayoutComponent, Request} from '@enonic-types/core';
 
 export const GET = function (req: Request) {
@@ -14,7 +15,7 @@ export const GET = function (req: Request) {
         path: content._path,
         name: content._name,
         editable: editMode,
-        resourcesPath: portal.assetUrl({path: ''}),
+        resourcesPath: assetUrl({path: ''}),
         component: component,
         centerRegion: component.regions["center"]
     });

--- a/src/main/resources/cms/pages/sse/sse.ts
+++ b/src/main/resources/cms/pages/sse/sse.ts
@@ -1,5 +1,6 @@
 import * as portal from '/lib/xp/portal';
 import * as thymeleaf from '/lib/thymeleaf';
+import {assetUrl} from '/lib/enonic/asset';
 import type {Request} from '@enonic-types/core';
 
 const view = resolve('sse.html');
@@ -7,10 +8,10 @@ const view = resolve('sse.html');
 export const GET = function (_req: Request) {
     const apiUrl = portal.apiUrl({api: 'com.enonic.app.features:sse'});
     const mappingUrl = portal.pageUrl({path: portal.getSite()?._path + '/sse-mapping'});
-    const assetUrl = portal.assetUrl({path: 'js/pages/sse/sse.js'});
+    const sseAssetUrl = assetUrl({path: 'js/pages/sse/sse.js'});
 
     return {
         contentType: 'text/html',
-        body: thymeleaf.render(view, {apiUrl, mappingUrl, assetUrl})
+        body: thymeleaf.render(view, {apiUrl, mappingUrl, assetUrl: sseAssetUrl})
     };
 };

--- a/src/main/resources/cms/parts/auditLog/auditLog.ts
+++ b/src/main/resources/cms/parts/auditLog/auditLog.ts
@@ -1,6 +1,7 @@
 import * as libPortal from '/lib/xp/portal';
 import * as libThymeleaf from '/lib/thymeleaf';
 import * as auditLib from '/lib/xp/auditlog';
+import {assetUrl} from '/lib/enonic/asset';
 import type {Request, RequestParams, UserKey} from '@enonic-types/core';
 import type {AuditLogParams, FindAuditLogParams} from '@enonic-types/lib-auditlog';
 
@@ -104,8 +105,8 @@ export const GET = function (req: Request) {
         }),
         pageContributions: {
             bodyEnd: [
-                '<script src="' + libPortal.assetUrl({path: 'js/jquery-2.1.4.min.js'}) + '" type="text/javascript"></script>',
-                '<script src="' + libPortal.assetUrl({path: 'js/parts/auditLog/auditLog.js'}) + '" type="text/javascript"></script>'
+                '<script src="' + assetUrl({path: 'js/jquery-2.1.4.min.js'}) + '" type="text/javascript"></script>',
+                '<script src="' + assetUrl({path: 'js/parts/auditLog/auditLog.js'}) + '" type="text/javascript"></script>'
             ]
         }
     };

--- a/src/main/resources/cms/parts/auth/auth.ts
+++ b/src/main/resources/cms/parts/auth/auth.ts
@@ -1,6 +1,7 @@
 import * as portal from '/lib/xp/portal';
 import * as thymeleaf from '/lib/thymeleaf';
 import * as auth from '/lib/xp/auth';
+import {assetUrl} from '/lib/enonic/asset';
 import type {Request, User, UserKey, GroupKey, RoleKey, PrincipalKey, PrincipalType} from '@enonic-types/core';
 import type {Group, Role, FindPrincipalsResult} from '@enonic-types/lib-auth';
 
@@ -29,11 +30,11 @@ export const GET = function (req: Request) {
         body: body,
         pageContributions: {
             headEnd: [
-                '<link rel="stylesheet" href="' + portal.assetUrl({path: 'css/parts/auth/auth.css'}) + '" type="text/css" />',
+                '<link rel="stylesheet" href="' + assetUrl({path: 'css/parts/auth/auth.css'}) + '" type="text/css" />',
             ],
             bodyEnd: [
-                '<script src="' + portal.assetUrl({path: 'js/jquery-2.1.4.min.js'}) + '" type="text/javascript"></script>',
-                '<script src="' + portal.assetUrl({path: 'js/parts/auth/auth.js'}) + '" type="text/javascript"></script>',
+                '<script src="' + assetUrl({path: 'js/jquery-2.1.4.min.js'}) + '" type="text/javascript"></script>',
+                '<script src="' + assetUrl({path: 'js/parts/auth/auth.js'}) + '" type="text/javascript"></script>',
             ]
         }
     };

--- a/src/main/resources/cms/parts/createContent/createContent.ts
+++ b/src/main/resources/cms/parts/createContent/createContent.ts
@@ -1,6 +1,7 @@
 import * as portal from '/lib/xp/portal';
 import * as thymeleaf from '/lib/thymeleaf';
 import * as contentSvc from '/lib/xp/content';
+import {assetUrl} from '/lib/enonic/asset';
 import type {PartComponent, Request} from '@enonic-types/core';
 
 export const GET = function (req: Request) {
@@ -34,8 +35,8 @@ export const GET = function (req: Request) {
         body: body,
         pageContributions: {
             bodyEnd: [
-                '<script src="' + portal.assetUrl({path: 'js/jquery-2.1.4.min.js'}) + '" type="text/javascript"></script>',
-                '<script src="' + portal.assetUrl({path: 'js/parts/createContent/createContent.js'}) + '" type="text/javascript"></script>',
+                '<script src="' + assetUrl({path: 'js/jquery-2.1.4.min.js'}) + '" type="text/javascript"></script>',
+                '<script src="' + assetUrl({path: 'js/parts/createContent/createContent.js'}) + '" type="text/javascript"></script>',
             ]
         }
     };
@@ -100,8 +101,8 @@ export const POST = function (req: Request) {
         body: body,
         pageContributions: {
             bodyEnd: [
-                '<script src="' + portal.assetUrl({path: 'js/jquery-2.1.4.min.js'}) + '" type="text/javascript"></script>',
-                '<script src="' + portal.assetUrl({path: 'js/parts/createContent/createContent.js'}) + '" type="text/javascript"></script>',
+                '<script src="' + assetUrl({path: 'js/jquery-2.1.4.min.js'}) + '" type="text/javascript"></script>',
+                '<script src="' + assetUrl({path: 'js/parts/createContent/createContent.js'}) + '" type="text/javascript"></script>',
             ]
         }
     };

--- a/src/main/resources/cms/parts/http/http.ts
+++ b/src/main/resources/cms/parts/http/http.ts
@@ -1,6 +1,7 @@
 import * as portal from '/lib/xp/portal';
 import * as httpClient from '/lib/http-client';
 import * as thymeleaf from '/lib/thymeleaf';
+import {assetUrl} from '/lib/enonic/asset';
 import type {Request} from '@enonic-types/core';
 import type {HttpRequestParams, HttpResponse} from '/lib/http-client';
 
@@ -25,11 +26,11 @@ export const GET = function (req: Request) {
         body: body,
         pageContributions: {
             headEnd: [
-                '<link rel="stylesheet" href="' + portal.assetUrl({path: 'css/parts/http/http.css'}) + '" type="text/css" />'
+                '<link rel="stylesheet" href="' + assetUrl({path: 'css/parts/http/http.css'}) + '" type="text/css" />'
             ],
             bodyEnd: [
-                '<script src="' + portal.assetUrl({path: 'js/jquery-2.1.4.min.js'}) + '" type="text/javascript"></script>',
-                '<script src="' + portal.assetUrl({path: 'js/parts/http/http.js'}) + '" type="text/javascript"></script>'
+                '<script src="' + assetUrl({path: 'js/jquery-2.1.4.min.js'}) + '" type="text/javascript"></script>',
+                '<script src="' + assetUrl({path: 'js/parts/http/http.js'}) + '" type="text/javascript"></script>'
             ]
         }
     };

--- a/src/main/resources/cms/parts/images/images.ts
+++ b/src/main/resources/cms/parts/images/images.ts
@@ -1,6 +1,7 @@
 import * as portal from '/lib/xp/portal';
 import * as contentSvc from '/lib/xp/content';
 import * as thymeleaf from '/lib/thymeleaf';
+import {assetUrl} from '/lib/enonic/asset';
 import type {PartComponent, Request} from '@enonic-types/core';
 import type {ImageUrlParams} from '@enonic-types/lib-portal';
 
@@ -62,8 +63,8 @@ export const GET = function (req: Request) {
         body: body,
         pageContributions: {
             bodyEnd: [
-                '<script src="' + portal.assetUrl({path: 'js/jquery-2.1.4.min.js'}) + '" type="text/javascript"></script>',
-                '<script src="' + portal.assetUrl({path: 'js/images-part.js'}) + '" type="text/javascript"></script>'
+                '<script src="' + assetUrl({path: 'js/jquery-2.1.4.min.js'}) + '" type="text/javascript"></script>',
+                '<script src="' + assetUrl({path: 'js/images-part.js'}) + '" type="text/javascript"></script>'
             ]
         }
     };

--- a/src/main/resources/cms/parts/mail/mail.ts
+++ b/src/main/resources/cms/parts/mail/mail.ts
@@ -1,6 +1,7 @@
 import * as portal from '/lib/xp/portal';
 import * as mail from '/lib/xp/mail';
 import * as thymeleaf from '/lib/thymeleaf';
+import {assetUrl} from '/lib/enonic/asset';
 import type {Request} from '@enonic-types/core';
 import type {Attachment} from '@enonic-types/lib-mail';
 
@@ -22,7 +23,7 @@ export const GET = function (req: Request) {
         body: body,
         pageContributions: {
             headEnd: [
-                '<link rel="stylesheet" href="' + portal.assetUrl({path: 'css/parts/mail/mail.css'}) + '" type="text/css" />'
+                '<link rel="stylesheet" href="' + assetUrl({path: 'css/parts/mail/mail.css'}) + '" type="text/css" />'
             ]
         }
     };

--- a/src/main/resources/cms/parts/memberships/memberships.ts
+++ b/src/main/resources/cms/parts/memberships/memberships.ts
@@ -1,6 +1,7 @@
 import * as portal from '/lib/xp/portal';
 import * as auth from '/lib/xp/auth';
 import * as thymeleaf from '/lib/thymeleaf';
+import {assetUrl} from '/lib/enonic/asset';
 import type {Request, Principal, PrincipalKey, PrincipalType, GroupKey, RoleKey, UserKey} from '@enonic-types/core';
 import type {Group, Role, User, FindPrincipalsResult} from '@enonic-types/lib-auth';
 
@@ -21,11 +22,11 @@ export const GET = function (req: Request) {
         body: body,
         pageContributions: {
             headEnd: [
-                '<link rel="stylesheet" href="' + portal.assetUrl({path: 'css/parts/memberships/memberships.css'}) + '" type="text/css" />',
+                '<link rel="stylesheet" href="' + assetUrl({path: 'css/parts/memberships/memberships.css'}) + '" type="text/css" />',
             ],
             bodyEnd: [
-                '<script src="' + portal.assetUrl({path: 'js/jquery-2.1.4.min.js'}) + '" type="text/javascript"></script>',
-                '<script src="' + portal.assetUrl({path: 'js/parts/memberships/memberships.js'}) + '" type="text/javascript"></script>',
+                '<script src="' + assetUrl({path: 'js/jquery-2.1.4.min.js'}) + '" type="text/javascript"></script>',
+                '<script src="' + assetUrl({path: 'js/parts/memberships/memberships.js'}) + '" type="text/javascript"></script>',
             ]
         }
     };

--- a/src/main/resources/cms/parts/moveContent/moveContent.ts
+++ b/src/main/resources/cms/parts/moveContent/moveContent.ts
@@ -1,6 +1,7 @@
 import * as portal from '/lib/xp/portal';
 import * as contentLib from '/lib/xp/content';
 import * as thymeleaf from '/lib/thymeleaf';
+import {assetUrl} from '/lib/enonic/asset';
 import type {Request} from '@enonic-types/core';
 
 const view = resolve('moveContent.html');
@@ -19,8 +20,8 @@ export const GET = function (req: Request) {
         body: body,
         pageContributions: {
             bodyEnd: [
-                '<script src="' + portal.assetUrl({path: 'js/jquery-2.1.4.min.js'}) + '" type="text/javascript"></script>',
-                '<script src="' + portal.assetUrl({path: 'js/parts/moveContent/moveContent.js'}) + '" type="text/javascript"></script>',
+                '<script src="' + assetUrl({path: 'js/jquery-2.1.4.min.js'}) + '" type="text/javascript"></script>',
+                '<script src="' + assetUrl({path: 'js/parts/moveContent/moveContent.js'}) + '" type="text/javascript"></script>',
             ]
         }
     };
@@ -63,8 +64,8 @@ export const POST = function (req: Request) {
         body: body,
         pageContributions: {
             bodyEnd: [
-                '<script src="' + portal.assetUrl({path: 'js/jquery-2.1.4.min.js'}) + '" type="text/javascript"></script>',
-                '<script src="' + portal.assetUrl({path: 'js/parts/moveContent/moveContent.js'}) + '" type="text/javascript"></script>',
+                '<script src="' + assetUrl({path: 'js/jquery-2.1.4.min.js'}) + '" type="text/javascript"></script>',
+                '<script src="' + assetUrl({path: 'js/parts/moveContent/moveContent.js'}) + '" type="text/javascript"></script>',
             ]
         }
     };

--- a/src/main/resources/cms/parts/publish/publish.ts
+++ b/src/main/resources/cms/parts/publish/publish.ts
@@ -1,6 +1,7 @@
 import * as portal from '/lib/xp/portal';
 import * as contentLib from '/lib/xp/content';
 import * as thymeleaf from '/lib/thymeleaf';
+import {assetUrl} from '/lib/enonic/asset';
 import type {Request} from '@enonic-types/core';
 
 export const GET = function (req: Request) {
@@ -14,11 +15,11 @@ export const GET = function (req: Request) {
         body: body,
         pageContributions: {
             headEnd: [
-                '<link rel="stylesheet" href="' + portal.assetUrl({path: 'css/parts/publish/publish.css'}) + '" type="text/css" />'
+                '<link rel="stylesheet" href="' + assetUrl({path: 'css/parts/publish/publish.css'}) + '" type="text/css" />'
             ],
             bodyEnd: [
-                '<script src="' + portal.assetUrl({path: 'js/jquery-2.1.4.min.js'}) + '" type="text/javascript"></script>',
-                '<script src="' + portal.assetUrl({path: 'js/parts/publish/publish.js'}) + '" type="text/javascript"></script>'
+                '<script src="' + assetUrl({path: 'js/jquery-2.1.4.min.js'}) + '" type="text/javascript"></script>',
+                '<script src="' + assetUrl({path: 'js/parts/publish/publish.js'}) + '" type="text/javascript"></script>'
             ]
         }
     };

--- a/src/main/resources/cms/parts/sanitize/sanitize.ts
+++ b/src/main/resources/cms/parts/sanitize/sanitize.ts
@@ -1,6 +1,7 @@
 import * as portal from '/lib/xp/portal';
 import * as ioLib from '/lib/xp/io';
 import * as thymeleaf from '/lib/thymeleaf';
+import {assetUrl} from '/lib/enonic/asset';
 import type {Request} from '@enonic-types/core';
 
 export const GET = function (req: Request) {
@@ -23,19 +24,19 @@ export const GET = function (req: Request) {
         body: body,
         pageContributions: {
             headEnd: [
-                '<link rel="stylesheet" href="' + portal.assetUrl({path: 'css/parts/sanitize/codemirror.css'}) + '" type="text/css" />',
-                '<link rel="stylesheet" href="' + portal.assetUrl({path: 'css/parts/sanitize/sanitize.css'}) + '" type="text/css" />'
+                '<link rel="stylesheet" href="' + assetUrl({path: 'css/parts/sanitize/codemirror.css'}) + '" type="text/css" />',
+                '<link rel="stylesheet" href="' + assetUrl({path: 'css/parts/sanitize/sanitize.css'}) + '" type="text/css" />'
             ],
             bodyEnd: [
-                '<script src="' + portal.assetUrl({path: 'js/jquery-2.1.4.min.js'}) + '" type="text/javascript"></script>',
-                '<script src="' + portal.assetUrl({path: 'js/parts/sanitize/codemirror.js'}) + '" type="text/javascript"></script>',
-                '<script src="' + portal.assetUrl({path: 'js/parts/sanitize/mode/css/css.js'}) + '" type="text/javascript"></script>',
-                '<script src="' + portal.assetUrl({path: 'js/parts/sanitize/mode/javascript/javascript.js'}) +
+                '<script src="' + assetUrl({path: 'js/jquery-2.1.4.min.js'}) + '" type="text/javascript"></script>',
+                '<script src="' + assetUrl({path: 'js/parts/sanitize/codemirror.js'}) + '" type="text/javascript"></script>',
+                '<script src="' + assetUrl({path: 'js/parts/sanitize/mode/css/css.js'}) + '" type="text/javascript"></script>',
+                '<script src="' + assetUrl({path: 'js/parts/sanitize/mode/javascript/javascript.js'}) +
                 '" type="text/javascript"></script>',
-                '<script src="' + portal.assetUrl({path: 'js/parts/sanitize/mode/xml/xml.js'}) + '" type="text/javascript"></script>',
-                '<script src="' + portal.assetUrl({path: 'js/parts/sanitize/mode/htmlmixed/htmlmixed.js'}) +
+                '<script src="' + assetUrl({path: 'js/parts/sanitize/mode/xml/xml.js'}) + '" type="text/javascript"></script>',
+                '<script src="' + assetUrl({path: 'js/parts/sanitize/mode/htmlmixed/htmlmixed.js'}) +
                 '" type="text/javascript"></script>',
-                '<script src="' + portal.assetUrl({path: 'js/parts/sanitize/sanitize.js'}) + '" type="text/javascript"></script>'
+                '<script src="' + assetUrl({path: 'js/parts/sanitize/sanitize.js'}) + '" type="text/javascript"></script>'
             ]
         }
     };

--- a/src/main/resources/cms/parts/scheduler/scheduler.ts
+++ b/src/main/resources/cms/parts/scheduler/scheduler.ts
@@ -1,6 +1,7 @@
 import * as libPortal from '/lib/xp/portal';
 import * as libScheduler from '/lib/xp/scheduler';
 import * as libThymeleaf from '/lib/thymeleaf';
+import {assetUrl} from '/lib/enonic/asset';
 import type {Request, RequestParams} from '@enonic-types/core';
 import type {ScheduledJob} from '@enonic-types/lib-scheduler';
 
@@ -96,8 +97,8 @@ export const GET = function (req: Request) {
         }),
         pageContributions: {
             bodyEnd: [
-                '<script src="' + libPortal.assetUrl({path: 'js/jquery-2.1.4.min.js'}) + '" type="text/javascript"></script>',
-                '<script src="' + libPortal.assetUrl({path: 'js/parts/scheduler/scheduler.js'}) + '" type="text/javascript"></script>'
+                '<script src="' + assetUrl({path: 'js/jquery-2.1.4.min.js'}) + '" type="text/javascript"></script>',
+                '<script src="' + assetUrl({path: 'js/parts/scheduler/scheduler.js'}) + '" type="text/javascript"></script>'
             ]
         }
     };

--- a/src/main/resources/cms/parts/unpublish/unpublish.ts
+++ b/src/main/resources/cms/parts/unpublish/unpublish.ts
@@ -1,6 +1,7 @@
 import * as portal from '/lib/xp/portal';
 import * as contentLib from '/lib/xp/content';
 import * as thymeleaf from '/lib/thymeleaf';
+import {assetUrl} from '/lib/enonic/asset';
 import type {Request} from '@enonic-types/core';
 
 export const GET = function (req: Request) {
@@ -14,11 +15,11 @@ export const GET = function (req: Request) {
         body: body,
         pageContributions: {
             headEnd: [
-                '<link rel="stylesheet" href="' + portal.assetUrl({path: 'css/parts/unpublish/unpublish.css'}) + '" type="text/css" />'
+                '<link rel="stylesheet" href="' + assetUrl({path: 'css/parts/unpublish/unpublish.css'}) + '" type="text/css" />'
             ],
             bodyEnd: [
-                '<script src="' + portal.assetUrl({path: 'js/jquery-2.1.4.min.js'}) + '" type="text/javascript"></script>',
-                '<script src="' + portal.assetUrl({path: 'js/parts/unpublish/unpublish.js'}) + '" type="text/javascript"></script>'
+                '<script src="' + assetUrl({path: 'js/jquery-2.1.4.min.js'}) + '" type="text/javascript"></script>',
+                '<script src="' + assetUrl({path: 'js/parts/unpublish/unpublish.js'}) + '" type="text/javascript"></script>'
             ]
         }
     };

--- a/src/main/resources/cms/processors/branch-filter.ts
+++ b/src/main/resources/cms/processors/branch-filter.ts
@@ -1,5 +1,5 @@
 import type { Request, MappedResponse } from '@enonic-types/core';
-import * as portal from '/lib/xp/portal';
+import { assetUrl } from '/lib/enonic/asset';
 
 export const responseProcessor = function(req: Request, res: MappedResponse) {
     const isHtml = (res.contentType.lastIndexOf('text/html', 0) === 0);
@@ -7,7 +7,7 @@ export const responseProcessor = function(req: Request, res: MappedResponse) {
         addPageContribution(res, 'bodyEnd', '<input type="hidden" name="branch" value="' + req.branch + '"/>');
     }
 
-    const scriptUrl = portal.assetUrl({path: 'filters/branch-filter.js'});
+    const scriptUrl = assetUrl({path: 'filters/branch-filter.js'});
     addPageContribution(res, 'bodyEnd', '<script src="' + scriptUrl + '" type="text/javascript"></script>');
 
     return res;

--- a/src/main/resources/cms/site.yaml
+++ b/src/main/resources/cms/site.yaml
@@ -1,5 +1,6 @@
 kind: "Site"
 apis:
+  - "asset"
   - "com.enonic.app.features:sse"
 processors:
   - name: "bgcolor-filter"

--- a/src/main/resources/lib/jslibraries/portal.ts
+++ b/src/main/resources/lib/jslibraries/portal.ts
@@ -1,7 +1,7 @@
-export function assetUrl() {
-    const portal = require('/lib/xp/portal');
+import {assetUrl as assetLibAssetUrl} from '/lib/enonic/asset';
 
-    const url = portal.assetUrl({
+export function assetUrl() {
+    const url = assetLibAssetUrl({
         path: 'error/css/custom.css',
     });
 

--- a/src/main/resources/services/customSelector/customSelector.ts
+++ b/src/main/resources/services/customSelector/customSelector.ts
@@ -1,4 +1,4 @@
-import * as portalLib from '/lib/xp/portal';
+import { assetUrl } from '/lib/enonic/asset';
 import type { Request, RequestParams } from '@enonic-types/core';
 
 interface CustomSelectorHelper {
@@ -24,7 +24,7 @@ function getItems() {
         id: 1,
         displayName: "Option number 1",
         description: "External SVG file is used as icon",
-        iconUrl: portalLib.assetUrl({path: 'images/number_1.svg'}),
+        iconUrl: assetUrl({path: 'images/number_1.svg'}),
         icon: null
     }, {
         id: 2,

--- a/src/main/resources/tsconfig.json
+++ b/src/main/resources/tsconfig.json
@@ -10,6 +10,9 @@
       "/lib/xp/*": [
         "../../../node_modules/@enonic-types/lib-*"
       ],
+      "/lib/enonic/asset": [
+        "../../../node_modules/@enonic-types/lib-asset"
+      ],
       "/lib/thymeleaf": [
         "./types/thymeleaf"
       ],

--- a/tsup/server.ts
+++ b/tsup/server.ts
@@ -50,6 +50,7 @@ export default function buildServerConfig(): Options {
 
     external: [
       '/lib/cache',
+      '/lib/enonic/asset',
       '/lib/enonic/static',
       /^\/lib\/guillotine/,
       '/lib/graphql',


### PR DESCRIPTION
Replaced deprecated `portal.assetUrl` calls with `assetUrl` from `/lib/enonic/asset`. Wired up the library: dep added in `build.gradle`, registered `apis: ["asset"]` in `src/main/resources/cms/site.yaml`, added `@enonic-types/lib-asset` (+ path mapping in `src/main/resources/tsconfig.json`), and marked `/lib/enonic/asset` external in `tsup/server.ts`. Thymeleaf `${portal.assetUrl(...)}` view functions were intentionally left alone (separate Thymeleaf feature, not the deprecated JS API).

Closes #243

### Files touched (JS callers)

- `cms/processors/branch-filter.ts`
- `cms/error/error.ts`
- `cms/pages/sse/sse.ts`
- `cms/layouts/{centered,layout-25-75,layout-3-col,layout-htmlarea}/*.ts`
- `cms/parts/{auditLog,auth,createContent,http,images,mail,memberships,moveContent,publish,sanitize,scheduler,unpublish}/*.ts`
- `lib/jslibraries/portal.ts` (the `assetUrl()` demo wrapper)
- `services/customSelector/customSelector.ts`

### Test plan

- [x] `./gradlew build --refresh-dependencies` passes (incl. `npmCheck`)
- [x] Smoke-tested in the inline XP-in-/tmp E2E flow inside `claude-dev`:
  - App bundle reaches ACTIVE (`Started application com.enonic.app.features`)
  - Error page (`cms/error/error.ts`) renders `assetUrl`-generated `/site/features/draft/features/_/com.enonic.app.features:asset/<fingerprint>/error/css/custom.css` and `…/error/img/nick-hanging-from-cloud.svg`; both fetch HTTP 200 with `text/css` and `image/svg+xml` Content-Types and `Cache-Control: public, max-age=31536000, immutable`
  - `services/customSelector/customSelector.ts` JSON response carries an `iconUrl` of the same form for `images/number_1.svg`, and fetching that URL returns HTTP 200 / `image/svg+xml`

<sub>*Drafted with AI assistance*</sub>