### PR TITLE
Migrate to XP 8 lib-project API

### DIFF
--- a/src/main/resources/main.ts
+++ b/src/main/resources/main.ts
@@ -11,9 +11,7 @@ const projectData = {
     displayName: 'Features',
     description: 'Testing features for Enonic XP',
     language: 'en',
-    readAccess: {
-        public: true
-    }
+    publicRead: true
 }
 
 function runInContext(callback: () => unknown) {

--- a/src/main/resources/types/lib-project.d.ts
+++ b/src/main/resources/types/lib-project.d.ts
@@ -1,0 +1,7 @@
+declare module '@enonic-types/lib-project' {
+    function create<Config extends Record<string, unknown> = Record<string, unknown>>(
+        params: Omit<CreateProjectParams<Config>, 'readAccess'> & { publicRead: boolean }
+    ): Project<Config>;
+}
+
+export {};


### PR DESCRIPTION
Switched `main.ts` from the old `readAccess: {public: true}` shape to the new
`publicRead: true` shape introduced for `/lib/xp/project` on XP 8 in
[enonic/xp#12043](https://github.com/enonic/xp/pull/12043). Without this the
startup hook fails at runtime on XP 8 master.

Added a small `types/lib-project.d.ts` augmentation that overrides
`create()`'s parameter shape, because the latest published
`@enonic-types/lib-project` (`8.0.0-B4`, 2026-04-30) still declares the old
`readAccess` field. The augmentation can be deleted once a newer
`@enonic-types/lib-project` ships with the new shape.

See also the XP 8 upgrade notes in
[`enonic/doc-code` `docs/upgrade.adoc`](https://github.com/enonic/doc-code/blob/master/docs/upgrade.adoc)
(lib-content + lib-project sections).

<sub>*Drafted with AI assistance*</sub>