### PR TITLE
Fix sorting by displayName #250

### DIFF
--- a/src/main/resources/import/features/_/node.xml
+++ b/src/main/resources/import/features/_/node.xml
@@ -310,6 +310,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/features/_templates/_/node.xml
+++ b/src/main/resources/import/features/_templates/_/node.xml
@@ -174,6 +174,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/features/_templates/default/_/node.xml
+++ b/src/main/resources/import/features/_templates/default/_/node.xml
@@ -230,6 +230,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/features/_templates/main/_/node.xml
+++ b/src/main/resources/import/features/_templates/main/_/node.xml
@@ -292,6 +292,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/features/_templates/no-regions/_/node.xml
+++ b/src/main/resources/import/features/_templates/no-regions/_/node.xml
@@ -292,6 +292,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/features/_templates/reference-test/_/node.xml
+++ b/src/main/resources/import/features/_templates/reference-test/_/node.xml
@@ -315,6 +315,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/features/input-types/_/node.xml
+++ b/src/main/resources/import/features/input-types/_/node.xml
@@ -112,6 +112,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/features/input-types/articles/_/node.xml
+++ b/src/main/resources/import/features/input-types/articles/_/node.xml
@@ -175,6 +175,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/features/input-types/articles/my-article/_/node.xml
+++ b/src/main/resources/import/features/input-types/articles/my-article/_/node.xml
@@ -179,6 +179,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/features/input-types/date-and-time/_/node.xml
+++ b/src/main/resources/import/features/input-types/date-and-time/_/node.xml
@@ -122,6 +122,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/features/input-types/date-and-time/datetime-queries/2015-08-01-0100/_/node.xml
+++ b/src/main/resources/import/features/input-types/date-and-time/datetime-queries/2015-08-01-0100/_/node.xml
@@ -125,6 +125,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/features/input-types/date-and-time/datetime-queries/2025-08-01-0200/_/node.xml
+++ b/src/main/resources/import/features/input-types/date-and-time/datetime-queries/2025-08-01-0200/_/node.xml
@@ -125,6 +125,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/features/input-types/date-and-time/datetime-queries/_/node.xml
+++ b/src/main/resources/import/features/input-types/date-and-time/datetime-queries/_/node.xml
@@ -255,6 +255,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/features/input-types/geo-point/_/node.xml
+++ b/src/main/resources/import/features/input-types/geo-point/_/node.xml
@@ -112,6 +112,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/features/input-types/geo-point/cities-manager/_/node.xml
+++ b/src/main/resources/import/features/input-types/geo-point/cities-manager/_/node.xml
@@ -267,6 +267,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/features/input-types/geo-point/cities-manager/barcelona/_/node.xml
+++ b/src/main/resources/import/features/input-types/geo-point/cities-manager/barcelona/_/node.xml
@@ -114,6 +114,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/features/input-types/geo-point/cities-manager/bergen/_/node.xml
+++ b/src/main/resources/import/features/input-types/geo-point/cities-manager/bergen/_/node.xml
@@ -114,6 +114,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/features/input-types/geo-point/cities-manager/bogotá/_/node.xml
+++ b/src/main/resources/import/features/input-types/geo-point/cities-manager/bogotá/_/node.xml
@@ -115,6 +115,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/features/input-types/geo-point/cities-manager/minsk/_/node.xml
+++ b/src/main/resources/import/features/input-types/geo-point/cities-manager/minsk/_/node.xml
@@ -114,6 +114,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/features/input-types/geo-point/cities-manager/oslo/_/node.xml
+++ b/src/main/resources/import/features/input-types/geo-point/cities-manager/oslo/_/node.xml
@@ -115,6 +115,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/features/input-types/geo-point/cities-manager/paris/_/node.xml
+++ b/src/main/resources/import/features/input-types/geo-point/cities-manager/paris/_/node.xml
@@ -114,6 +114,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/features/input-types/geo-point/cities-manager/samara/_/node.xml
+++ b/src/main/resources/import/features/input-types/geo-point/cities-manager/samara/_/node.xml
@@ -114,6 +114,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/features/input-types/geo-point/cities-manager/san francisco/_/node.xml
+++ b/src/main/resources/import/features/input-types/geo-point/cities-manager/san francisco/_/node.xml
@@ -115,6 +115,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/features/input-types/geo-point/cities-manager/sydney/_/node.xml
+++ b/src/main/resources/import/features/input-types/geo-point/cities-manager/sydney/_/node.xml
@@ -114,6 +114,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/features/input-types/geo-point/cities-manager/tromsø/_/node.xml
+++ b/src/main/resources/import/features/input-types/geo-point/cities-manager/tromsø/_/node.xml
@@ -114,6 +114,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/features/input-types/references/_/node.xml
+++ b/src/main/resources/import/features/input-types/references/_/node.xml
@@ -175,6 +175,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/features/input-types/references/ref1/_/node.xml
+++ b/src/main/resources/import/features/input-types/references/ref1/_/node.xml
@@ -177,6 +177,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/features/input-types/references/ref2/_/node.xml
+++ b/src/main/resources/import/features/input-types/references/ref2/_/node.xml
@@ -177,6 +177,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/features/input-types/references/ref3/_/node.xml
+++ b/src/main/resources/import/features/input-types/references/ref3/_/node.xml
@@ -179,6 +179,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/features/input-types/references/ref4/_/node.xml
+++ b/src/main/resources/import/features/input-types/references/ref4/_/node.xml
@@ -179,6 +179,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/features/input-types/selector/_/node.xml
+++ b/src/main/resources/import/features/input-types/selector/_/node.xml
@@ -175,6 +175,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/features/input-types/selector/another-selector-test/_/node.xml
+++ b/src/main/resources/import/features/input-types/selector/another-selector-test/_/node.xml
@@ -175,6 +175,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/features/input-types/selector/article-in-selector-folder/_/node.xml
+++ b/src/main/resources/import/features/input-types/selector/article-in-selector-folder/_/node.xml
@@ -179,6 +179,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/features/input-types/selector/selector-allow-test/_/node.xml
+++ b/src/main/resources/import/features/input-types/selector/selector-allow-test/_/node.xml
@@ -175,6 +175,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/features/js-libraries/Upload/_/node.xml
+++ b/src/main/resources/import/features/js-libraries/Upload/_/node.xml
@@ -176,6 +176,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/features/js-libraries/_/node.xml
+++ b/src/main/resources/import/features/js-libraries/_/node.xml
@@ -175,6 +175,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/features/js-libraries/audit-logs/_/node.xml
+++ b/src/main/resources/import/features/js-libraries/audit-logs/_/node.xml
@@ -318,6 +318,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/features/js-libraries/auth/_/node.xml
+++ b/src/main/resources/import/features/js-libraries/auth/_/node.xml
@@ -240,6 +240,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/features/js-libraries/cluster/_/node.xml
+++ b/src/main/resources/import/features/js-libraries/cluster/_/node.xml
@@ -325,6 +325,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/features/js-libraries/content-publish/_/node.xml
+++ b/src/main/resources/import/features/js-libraries/content-publish/_/node.xml
@@ -247,6 +247,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/features/js-libraries/content-unpublish/_/node.xml
+++ b/src/main/resources/import/features/js-libraries/content-unpublish/_/node.xml
@@ -247,6 +247,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/features/js-libraries/content/_/node.xml
+++ b/src/main/resources/import/features/js-libraries/content/_/node.xml
@@ -308,6 +308,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/features/js-libraries/context/_/node.xml
+++ b/src/main/resources/import/features/js-libraries/context/_/node.xml
@@ -308,6 +308,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/features/js-libraries/houses/_/node.xml
+++ b/src/main/resources/import/features/js-libraries/houses/_/node.xml
@@ -175,6 +175,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/features/js-libraries/houses/house1/_/node.xml
+++ b/src/main/resources/import/features/js-libraries/houses/house1/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/features/js-libraries/houses/house2/_/node.xml
+++ b/src/main/resources/import/features/js-libraries/houses/house2/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/features/js-libraries/houses/house3/_/node.xml
+++ b/src/main/resources/import/features/js-libraries/houses/house3/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/features/js-libraries/houses/house4/_/node.xml
+++ b/src/main/resources/import/features/js-libraries/houses/house4/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/features/js-libraries/houses/house5/_/node.xml
+++ b/src/main/resources/import/features/js-libraries/houses/house5/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/features/js-libraries/houses/house6/_/node.xml
+++ b/src/main/resources/import/features/js-libraries/houses/house6/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/features/js-libraries/http/_/node.xml
+++ b/src/main/resources/import/features/js-libraries/http/_/node.xml
@@ -240,6 +240,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/features/js-libraries/i18n/_/node.xml
+++ b/src/main/resources/import/features/js-libraries/i18n/_/node.xml
@@ -308,6 +308,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/features/js-libraries/mail/_/node.xml
+++ b/src/main/resources/import/features/js-libraries/mail/_/node.xml
@@ -240,6 +240,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/features/js-libraries/memberships/_/node.xml
+++ b/src/main/resources/import/features/js-libraries/memberships/_/node.xml
@@ -240,6 +240,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/features/js-libraries/multipart/_/node.xml
+++ b/src/main/resources/import/features/js-libraries/multipart/_/node.xml
@@ -247,6 +247,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/features/js-libraries/node/_/node.xml
+++ b/src/main/resources/import/features/js-libraries/node/_/node.xml
@@ -305,6 +305,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/features/js-libraries/portal/_/node.xml
+++ b/src/main/resources/import/features/js-libraries/portal/_/node.xml
@@ -308,6 +308,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/features/js-libraries/repo/_/node.xml
+++ b/src/main/resources/import/features/js-libraries/repo/_/node.xml
@@ -305,6 +305,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/features/js-libraries/sanitize-html/_/node.xml
+++ b/src/main/resources/import/features/js-libraries/sanitize-html/_/node.xml
@@ -240,6 +240,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/features/js-libraries/schedule-publish/_/node.xml
+++ b/src/main/resources/import/features/js-libraries/schedule-publish/_/node.xml
@@ -308,6 +308,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/features/js-libraries/value/_/node.xml
+++ b/src/main/resources/import/features/js-libraries/value/_/node.xml
@@ -305,6 +305,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/features/js-libraries/view-functions/_/node.xml
+++ b/src/main/resources/import/features/js-libraries/view-functions/_/node.xml
@@ -325,6 +325,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/features/media/_/node.xml
+++ b/src/main/resources/import/features/media/_/node.xml
@@ -174,6 +174,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/features/media/archive/_/node.xml
+++ b/src/main/resources/import/features/media/archive/_/node.xml
@@ -174,6 +174,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/features/media/audio/_/node.xml
+++ b/src/main/resources/import/features/media/audio/_/node.xml
@@ -174,6 +174,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/features/media/audio/the-irish-washerwoman-mp3/_/node.xml
+++ b/src/main/resources/import/features/media/audio/the-irish-washerwoman-mp3/_/node.xml
@@ -183,6 +183,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/features/media/image/Adansonia_grandidieri_02.jpg/_/node.xml
+++ b/src/main/resources/import/features/media/image/Adansonia_grandidieri_02.jpg/_/node.xml
@@ -236,6 +236,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/features/media/image/An_Afghan_elder_and_his_cat_sit_outside_his_store.jpg/_/node.xml
+++ b/src/main/resources/import/features/media/image/An_Afghan_elder_and_his_cat_sit_outside_his_store.jpg/_/node.xml
@@ -170,6 +170,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/features/media/image/Cahabón_River_Semuc_Champey_Guatemala.jpg/_/node.xml
+++ b/src/main/resources/import/features/media/image/Cahabón_River_Semuc_Champey_Guatemala.jpg/_/node.xml
@@ -235,6 +235,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/features/media/image/Cape_Agulhas_P1040396.JPG/_/node.xml
+++ b/src/main/resources/import/features/media/image/Cape_Agulhas_P1040396.JPG/_/node.xml
@@ -235,6 +235,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/features/media/image/Castillo_de_Petrela_Petrela_Albania_2014-04-17_DD_09.JPG/_/node.xml
+++ b/src/main/resources/import/features/media/image/Castillo_de_Petrela_Petrela_Albania_2014-04-17_DD_09.JPG/_/node.xml
@@ -235,6 +235,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/features/media/image/Chichicastenango-004-denoised.jpg/_/node.xml
+++ b/src/main/resources/import/features/media/image/Chichicastenango-004-denoised.jpg/_/node.xml
@@ -235,6 +235,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/features/media/image/Elephant_(Loxodonta_Africana)_04.jpg/_/node.xml
+++ b/src/main/resources/import/features/media/image/Elephant_(Loxodonta_Africana)_04.jpg/_/node.xml
@@ -235,6 +235,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/features/media/image/GT22CU_Tren_a_las_nubes.JPG/_/node.xml
+++ b/src/main/resources/import/features/media/image/GT22CU_Tren_a_las_nubes.JPG/_/node.xml
@@ -235,6 +235,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/features/media/image/Gasa_Dzong.jpg/_/node.xml
+++ b/src/main/resources/import/features/media/image/Gasa_Dzong.jpg/_/node.xml
@@ -236,6 +236,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/features/media/image/Renault4_R01.jpg/_/node.xml
+++ b/src/main/resources/import/features/media/image/Renault4_R01.jpg/_/node.xml
@@ -236,6 +236,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/features/media/image/_/node.xml
+++ b/src/main/resources/import/features/media/image/_/node.xml
@@ -174,6 +174,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/features/media/image/dictyophorusspumans01-jpg/_/node.xml
+++ b/src/main/resources/import/features/media/image/dictyophorusspumans01-jpg/_/node.xml
@@ -235,6 +235,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/features/patchContent/_/node.xml
+++ b/src/main/resources/import/features/patchContent/_/node.xml
@@ -150,6 +150,19 @@
                 </indexConfig>
                 <path>components</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/features/portal-functions/_/node.xml
+++ b/src/main/resources/import/features/portal-functions/_/node.xml
@@ -112,6 +112,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/features/portal-functions/getcomponent/_/node.xml
+++ b/src/main/resources/import/features/portal-functions/getcomponent/_/node.xml
@@ -255,6 +255,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/features/portal-functions/getcontent/_/node.xml
+++ b/src/main/resources/import/features/portal-functions/getcontent/_/node.xml
@@ -255,6 +255,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/features/portal-functions/getsite/_/node.xml
+++ b/src/main/resources/import/features/portal-functions/getsite/_/node.xml
@@ -255,6 +255,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/features/portal-functions/imageurl/_/node.xml
+++ b/src/main/resources/import/features/portal-functions/imageurl/_/node.xml
@@ -247,6 +247,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/features/portal-functions/localization/_/node.xml
+++ b/src/main/resources/import/features/portal-functions/localization/_/node.xml
@@ -245,6 +245,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/features/portal-functions/process-html/_/node.xml
+++ b/src/main/resources/import/features/portal-functions/process-html/_/node.xml
@@ -112,6 +112,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/features/portal-functions/process-html/page-manager/_/node.xml
+++ b/src/main/resources/import/features/portal-functions/process-html/page-manager/_/node.xml
@@ -112,6 +112,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/features/portal-functions/process-html/page-manager/forms/_/node.xml
+++ b/src/main/resources/import/features/portal-functions/process-html/page-manager/forms/_/node.xml
@@ -127,6 +127,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/features/portal-functions/process-html/page-manager/layouts/_/node.xml
+++ b/src/main/resources/import/features/portal-functions/process-html/page-manager/layouts/_/node.xml
@@ -135,6 +135,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/features/portal-functions/process-html/page-manager/lists/_/node.xml
+++ b/src/main/resources/import/features/portal-functions/process-html/page-manager/lists/_/node.xml
@@ -164,6 +164,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/features/portal-functions/process-html/page-manager/tables/_/node.xml
+++ b/src/main/resources/import/features/portal-functions/process-html/page-manager/tables/_/node.xml
@@ -244,6 +244,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/features/scheduler/_/node.xml
+++ b/src/main/resources/import/features/scheduler/_/node.xml
@@ -355,6 +355,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/features/sorting/_/node.xml
+++ b/src/main/resources/import/features/sorting/_/node.xml
@@ -112,6 +112,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/features/sorting/getchildren-test/_/node.xml
+++ b/src/main/resources/import/features/sorting/getchildren-test/_/node.xml
@@ -252,6 +252,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/features/sorting/getchildren-test/create-1-edit/_/node.xml
+++ b/src/main/resources/import/features/sorting/getchildren-test/create-1-edit/_/node.xml
@@ -125,6 +125,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/features/sorting/getchildren-test/create-2/_/node.xml
+++ b/src/main/resources/import/features/sorting/getchildren-test/create-2/_/node.xml
@@ -125,6 +125,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/features/sorting/getchildren-test/create-3/_/node.xml
+++ b/src/main/resources/import/features/sorting/getchildren-test/create-3/_/node.xml
@@ -125,6 +125,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/features/sorting/getchildren-test/create-4/_/node.xml
+++ b/src/main/resources/import/features/sorting/getchildren-test/create-4/_/node.xml
@@ -125,6 +125,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/features/sorting/getchildren-test/create-5/_/node.xml
+++ b/src/main/resources/import/features/sorting/getchildren-test/create-5/_/node.xml
@@ -125,6 +125,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/features/sse/_/node.xml
+++ b/src/main/resources/import/features/sse/_/node.xml
@@ -150,6 +150,19 @@
                 </indexConfig>
                 <path>components</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/_/node.xml
+++ b/src/main/resources/import/large-tree/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-1/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-1/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-1/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-1/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-10/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-10/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-100/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-100/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-11/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-11/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-12/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-12/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-13/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-13/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-14/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-14/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-15/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-15/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-16/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-16/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-17/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-17/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-18/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-18/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-19/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-19/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-2/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-2/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-20/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-20/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-21/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-21/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-22/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-22/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-23/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-23/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-24/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-24/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-25/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-25/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-26/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-26/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-27/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-27/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-28/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-28/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-29/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-29/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-3/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-3/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-30/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-30/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-31/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-31/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-32/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-32/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-33/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-33/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-34/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-34/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-35/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-35/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-36/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-36/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-37/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-37/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-38/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-38/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-39/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-39/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-4/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-4/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-40/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-40/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-41/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-41/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-42/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-42/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-43/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-43/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-44/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-44/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-45/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-45/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-46/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-46/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-47/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-47/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-48/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-48/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-49/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-49/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-5/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-5/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-50/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-50/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-51/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-51/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-52/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-52/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-53/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-53/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-54/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-54/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-55/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-55/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-56/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-56/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-57/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-57/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-58/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-58/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-59/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-59/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-6/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-6/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-60/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-60/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-61/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-61/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-62/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-62/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-63/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-63/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-64/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-64/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-65/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-65/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-66/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-66/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-67/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-67/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-68/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-68/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-69/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-69/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-7/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-7/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-70/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-70/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-71/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-71/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-72/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-72/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-73/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-73/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-74/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-74/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-75/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-75/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-76/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-76/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-77/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-77/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-78/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-78/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-79/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-79/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-8/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-8/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-80/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-80/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-81/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-81/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-82/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-82/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-83/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-83/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-84/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-84/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-85/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-85/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-86/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-86/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-87/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-87/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-88/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-88/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-89/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-89/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-9/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-9/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-90/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-90/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-91/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-91/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-92/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-92/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-93/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-93/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-94/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-94/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-95/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-95/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-96/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-96/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-97/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-97/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-98/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-98/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-99/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-1/large-tree-node-1-99/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-2/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-2/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-1/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-1/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-10/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-10/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-100/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-100/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-11/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-11/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-12/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-12/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-13/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-13/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-14/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-14/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-15/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-15/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-16/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-16/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-17/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-17/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-18/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-18/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-19/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-19/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-2/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-2/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-20/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-20/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-21/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-21/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-22/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-22/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-23/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-23/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-24/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-24/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-25/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-25/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-26/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-26/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-27/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-27/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-28/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-28/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-29/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-29/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-3/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-3/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-30/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-30/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-31/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-31/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-32/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-32/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-33/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-33/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-34/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-34/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-35/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-35/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-36/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-36/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-37/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-37/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-38/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-38/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-39/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-39/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-4/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-4/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-40/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-40/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-41/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-41/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-42/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-42/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-43/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-43/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-44/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-44/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-45/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-45/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-46/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-46/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-47/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-47/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-48/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-48/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-49/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-49/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-5/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-5/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-50/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-50/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-51/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-51/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-52/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-52/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-53/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-53/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-54/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-54/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-55/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-55/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-56/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-56/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-57/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-57/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-58/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-58/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-59/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-59/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-6/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-6/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-60/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-60/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-61/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-61/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-62/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-62/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-63/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-63/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-64/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-64/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-65/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-65/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-66/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-66/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-67/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-67/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-68/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-68/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-69/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-69/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-7/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-7/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-70/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-70/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-71/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-71/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-72/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-72/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-73/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-73/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-74/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-74/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-75/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-75/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-76/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-76/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-77/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-77/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-78/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-78/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-79/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-79/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-8/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-8/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-80/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-80/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-81/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-81/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-82/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-82/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-83/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-83/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-84/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-84/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-85/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-85/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-86/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-86/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-87/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-87/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-88/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-88/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-89/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-89/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-9/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-9/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-90/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-90/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-91/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-91/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-92/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-92/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-93/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-93/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-94/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-94/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-95/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-95/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-96/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-96/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-97/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-97/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-98/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-98/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-99/_/node.xml
+++ b/src/main/resources/import/large-tree/large-tree-node-2/large-tree-node-2-99/_/node.xml
@@ -182,6 +182,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>


### PR DESCRIPTION
Add a `pathIndexConfig` for `displayName` (FULLTEXT settings + `language=en`) to every imported `node.xml`. This mirrors what XP's `LanguageConfigProcessor` applies during `ContentService.create` on a `language=en` project, so the language-specific `_orderby_en` field is populated for imported content and `displayName` sorting yields the same collation as freshly created content.

Without this, the demo importer creates nodes whose `_orderby_en` field is empty, so child-order `displayName ASC/DESC` does not match the collation produced for freshly created content and sorting by `displayName` breaks.

Closes #250

Test plan:
- Install/build the app on a fresh XP.
- Run the demo importer.
- Verify content sorts correctly by `displayName` both in Content Studio and via a programmatic `findByParent` with sort `_displayName ASC`.

<sub>*Drafted with AI assistance*</sub>