### PR TITLE
Add WebSocket session demo

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group = com.enonic.app
 projectName = features
-xpVersion = 8.0.0
+xpVersion = 8.1.0-SNAPSHOT
 version = 8.0.0-SNAPSHOT
 

--- a/src/main/resources/apis/websocket-public/websocket-public.ts
+++ b/src/main/resources/apis/websocket-public/websocket-public.ts
@@ -1,0 +1,21 @@
+import type {Request} from '@enonic-types/core';
+import {handleEvent} from '/lib/ws-demo';
+
+export const GET = function (req: Request) {
+    if (!req.webSocket) {
+        return {
+            status: 426,
+            contentType: 'text/plain',
+            body: 'Public WebSocket endpoint. Connect over ws(s)://'
+        };
+    }
+
+    return {
+        webSocket: {
+            data: {mode: 'public'},
+            terminateOnSessionExit: false
+        }
+    };
+};
+
+export const webSocketEvent = handleEvent;

--- a/src/main/resources/apis/websocket-public/websocket-public.yaml
+++ b/src/main/resources/apis/websocket-public/websocket-public.yaml
@@ -1,0 +1,4 @@
+kind: "API"
+title: "WebSocket Session Demo (public)"
+allow:
+  - "role:system.everyone"

--- a/src/main/resources/apis/websocket/websocket.ts
+++ b/src/main/resources/apis/websocket/websocket.ts
@@ -1,0 +1,36 @@
+import type {Request} from '@enonic-types/core';
+import {handleEvent} from '/lib/ws-demo';
+
+interface SessionParams {
+    terminateOnSessionExit?: boolean;
+    sessionAccess?: boolean;
+    sessionAccessThrottleMs?: number;
+}
+
+const MODES: Record<string, SessionParams> = {
+    'default': {},
+    'survivor': {terminateOnSessionExit: false},
+    'keepalive': {sessionAccess: true, sessionAccessThrottleMs: 10000}
+};
+
+export const GET = function (req: Request) {
+    if (!req.webSocket) {
+        return {
+            status: 426,
+            contentType: 'text/plain',
+            body: 'WebSocket endpoint. Connect over ws(s):// with an optional ?mode=default|survivor|keepalive'
+        };
+    }
+
+    const requested = req.params.mode;
+    const mode = typeof requested === 'string' && requested in MODES ? requested : 'default';
+
+    return {
+        webSocket: {
+            data: {mode: mode},
+            ...MODES[mode]
+        }
+    };
+};
+
+export const webSocketEvent = handleEvent;

--- a/src/main/resources/apis/websocket/websocket.yaml
+++ b/src/main/resources/apis/websocket/websocket.yaml
@@ -1,0 +1,4 @@
+kind: "API"
+title: "WebSocket Session Demo"
+allow:
+  - "role:system.authenticated"

--- a/src/main/resources/assets/js/pages/websocket/websocket.js
+++ b/src/main/resources/assets/js/pages/websocket/websocket.js
@@ -1,0 +1,97 @@
+(function () {
+    const container = document.getElementById('ws-panels');
+    if (!container) {
+        return;
+    }
+
+    const defaultApiUrl = container.getAttribute('data-api-url');
+
+    container.querySelectorAll('.ws-panel').forEach(function (panel) {
+        const mode = panel.getAttribute('data-mode');
+        const statusEl = panel.querySelector('.ws-status');
+        const logEl = panel.querySelector('.ws-log');
+        const sendBtn = panel.querySelector('.ws-send');
+        const pingToggle = panel.querySelector('.ws-ping');
+        let pingTimer = null;
+        let opened = false;
+
+        function log(text) {
+            const item = document.createElement('li');
+            item.textContent = new Date().toLocaleTimeString() + ' ' + text;
+            logEl.appendChild(item);
+            logEl.scrollTop = logEl.scrollHeight;
+        }
+
+        const url = new URL(panel.getAttribute('data-api-url') || defaultApiUrl);
+        url.searchParams.set('mode', mode);
+        const ws = new WebSocket(url.toString());
+
+        ws.onopen = function () {
+            opened = true;
+            statusEl.textContent = 'open';
+            statusEl.classList.add('open');
+            sendBtn.disabled = false;
+            if (pingToggle) {
+                pingToggle.disabled = false;
+            }
+        };
+
+        ws.onmessage = function (e) {
+            log(e.data);
+        };
+
+        ws.onerror = function () {
+            log('(error)');
+        };
+
+        ws.onclose = function (e) {
+            const details = 'code ' + e.code + (e.reason ? ' "' + e.reason + '"' : '');
+            if (opened) {
+                statusEl.textContent = 'closed: ' + details;
+            } else {
+                statusEl.textContent = 'rejected — log in to connect';
+            }
+            statusEl.classList.remove('open');
+            statusEl.classList.add(e.code === 1008 ? 'terminated' : 'closed');
+            log((opened ? 'closed with ' : 'connection rejected, ') + details);
+            sendBtn.disabled = true;
+            if (pingTimer) {
+                clearInterval(pingTimer);
+                pingTimer = null;
+            }
+            if (pingToggle) {
+                pingToggle.checked = false;
+                pingToggle.disabled = true;
+            }
+        };
+
+        sendBtn.addEventListener('click', function () {
+            ws.send('hello from ' + mode);
+        });
+
+        if (pingToggle) {
+            pingToggle.addEventListener('change', function () {
+                if (pingToggle.checked) {
+                    pingTimer = setInterval(function () {
+                        ws.send('ping');
+                    }, 5000);
+                } else if (pingTimer) {
+                    clearInterval(pingTimer);
+                    pingTimer = null;
+                }
+            });
+        }
+    });
+
+    const logoutBtn = document.getElementById('ws-logout');
+    if (logoutBtn) {
+        logoutBtn.addEventListener('click', function () {
+            logoutBtn.disabled = true;
+            // The ID provider logout endpoint ends the session; fetch keeps the page (and its sockets) alive
+            // so the close frames stay visible.
+            fetch(logoutBtn.getAttribute('data-url')).then(function () {
+                document.getElementById('ws-logout-result').textContent = 'Session ended — watch the sockets.';
+            });
+        });
+    }
+})();

--- a/src/main/resources/cms/pages/websocket/websocket.html
+++ b/src/main/resources/cms/pages/websocket/websocket.html
@@ -1,0 +1,126 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>WebSocket Session Demo</title>
+    <style>
+        body { font-family: sans-serif; margin: 2rem; }
+        .ws-panels { display: flex; gap: 1rem; align-items: flex-start; flex-wrap: wrap; margin-top: 1rem; }
+        .ws-panel { border: 1px solid #ccc; border-radius: 6px; padding: 0 1rem 1rem; flex: 1 1 16rem; }
+        .ws-panel pre { background: #f6f6f6; padding: 0.5rem; overflow-x: auto; }
+        .ws-status { font-weight: bold; }
+        .ws-status.open { color: #1a7f37; }
+        .ws-status.closed { color: #b35900; }
+        .ws-status.terminated { color: #c00; }
+        .ws-log { list-style: none; padding: 0.5rem; margin: 0.5rem 0 0; background: #f6f6f6;
+                  font-family: monospace; font-size: 0.8rem; max-height: 12rem; overflow-y: auto; }
+    </style>
+</head>
+<body>
+<h1>WebSocket Session Demo</h1>
+<p>
+    WebSockets opened within an HTTP session are closed with code <code>1008</code> when that session ends —
+    both on logout and on idle-timeout expiry. The behavior is controlled per socket by the
+    <code>terminateOnSessionExit</code>, <code>sessionAccess</code> and <code>sessionAccessThrottleMs</code>
+    parameters of the controller's <code>webSocket</code> response.
+</p>
+
+<fieldset>
+    <legend>HTTP session</legend>
+    <div data-th-if="${user}">
+        <p>
+            Logged in as <strong data-th-text="${user.displayName}">user</strong>
+            (<code data-th-text="${user.key}">key</code>)
+        </p>
+        <p>
+            <button type="button" id="ws-logout" data-th-attr="data-url=${logoutUrl}">Logout</button>
+            <strong id="ws-logout-result"></strong>
+        </p>
+    </div>
+    <div data-th-unless="${user}">
+        <p><a data-th-href="${loginUrl}">Log in</a> via the ID provider, you will be redirected back here.</p>
+        <p><em>The three session sockets connect through an API that only allows
+            <code>role:system.authenticated</code> — while logged out their connections are rejected.
+            Only the <strong>public</strong> socket connects. Log in, then log out and watch them react.</em></p>
+    </div>
+</fieldset>
+
+<div class="ws-panels" id="ws-panels" data-th-attr="data-api-url=${apiUrl}">
+    <section class="ws-panel" data-mode="default">
+        <h3>default</h3>
+        <pre>webSocket: {
+    data: {...}
+}</pre>
+        <p>No session parameters — defaults apply: a socket opened within an HTTP session closes with <code>1008</code> when that session ends.</p>
+        <p><label><input type="checkbox" class="ws-ping" disabled/> ping every 5 s (does not refresh the session)</label></p>
+        <p class="ws-status">connecting…</p>
+        <p><button type="button" class="ws-send" disabled>Send message</button></p>
+        <ul class="ws-log"></ul>
+    </section>
+
+    <section class="ws-panel" data-mode="survivor">
+        <h3>survivor</h3>
+        <pre>webSocket: {
+    data: {...},
+    terminateOnSessionExit: false
+}</pre>
+        <p>Opts out of termination — the socket survives logout and session expiry.</p>
+        <p><label><input type="checkbox" class="ws-ping" disabled/> ping every 5 s (does not refresh the session)</label></p>
+        <p class="ws-status">connecting…</p>
+        <p><button type="button" class="ws-send" disabled>Send message</button></p>
+        <ul class="ws-log"></ul>
+    </section>
+
+    <section class="ws-panel" data-mode="keepalive">
+        <h3>keepalive</h3>
+        <pre>webSocket: {
+    data: {...},
+    sessionAccess: true,
+    sessionAccessThrottleMs: 10000
+}</pre>
+        <p>Inbound messages refresh the session (at most every 10 s). Still closes with <code>1008</code> when the session ends.</p>
+        <p><label><input type="checkbox" class="ws-ping" disabled/> ping every 5 s (refreshes the HTTP session)</label></p>
+        <p class="ws-status">connecting…</p>
+        <p><button type="button" class="ws-send" disabled>Send message</button></p>
+        <ul class="ws-log"></ul>
+    </section>
+
+    <section class="ws-panel" data-mode="public" data-th-attr="data-api-url=${publicApiUrl}">
+        <h3>public</h3>
+        <pre>allow: role:system.everyone
+
+webSocket: {
+    data: {...},
+    terminateOnSessionExit: false
+}</pre>
+        <p>Open to everyone — connects without login and never binds to the session.</p>
+        <p><label><input type="checkbox" class="ws-ping" disabled/> ping every 5 s (does not refresh the session)</label></p>
+        <p class="ws-status">connecting…</p>
+        <p><button type="button" class="ws-send" disabled>Send message</button></p>
+        <ul class="ws-log"></ul>
+    </section>
+</div>
+
+<p>
+    Note: sockets with no traffic for <code>websocket.idleTimeout</code> (default 5 min,
+    <code>com.enonic.xp.web.jetty.cfg</code>) are closed by the server with code <code>1001</code> —
+    that is the connection-level idle timeout, independent of the HTTP session. Turn the pings on to keep
+    connections busy; only the <em>keepalive</em> socket's pings refresh the session.
+</p>
+
+<details>
+    <summary>How to demo idle-timeout expiry</summary>
+    <p>
+        Set a short session timeout in <code>com.enonic.xp.web.jetty.cfg</code>:
+        <code>session.timeout = 1</code> (minutes), restart XP and log in here.
+        With the ping toggle ON, the keepalive socket's inbound messages keep the session alive
+        and all sockets stay open. Switch the pings OFF and stay idle: the session expires after
+        a minute and the scavenger (which sweeps at 1/10 of the session timeout, at least every
+        10&nbsp;s) invalidates it moments later — the <em>default</em> and <em>keepalive</em> sockets
+        close with <code>1008</code> while the <em>survivor</em> and <em>public</em> sockets stay open.
+    </p>
+</details>
+
+<script data-th-src="${scriptUrl}" defer></script>
+</body>
+</html>

--- a/src/main/resources/cms/pages/websocket/websocket.ts
+++ b/src/main/resources/cms/pages/websocket/websocket.ts
@@ -1,0 +1,23 @@
+import * as portal from '/lib/xp/portal';
+import * as thymeleaf from '/lib/thymeleaf';
+import * as auth from '/lib/xp/auth';
+import {assetUrl} from '/lib/enonic/asset';
+import type {Request} from '@enonic-types/core';
+
+const view = resolve('websocket.html');
+
+export const GET = function (_req: Request) {
+    const content = portal.getContent();
+
+    return {
+        contentType: 'text/html',
+        body: thymeleaf.render(view, {
+            user: auth.getUser(),
+            loginUrl: portal.loginUrl({redirect: portal.pageUrl({path: content._path, type: 'absolute'})}),
+            logoutUrl: portal.logoutUrl(),
+            apiUrl: portal.apiUrl({api: 'com.enonic.app.features:websocket', type: 'websocket'}),
+            publicApiUrl: portal.apiUrl({api: 'com.enonic.app.features:websocket-public', type: 'websocket'}),
+            scriptUrl: assetUrl({path: 'js/pages/websocket/websocket.js'})
+        })
+    };
+};

--- a/src/main/resources/cms/pages/websocket/websocket.yaml
+++ b/src/main/resources/cms/pages/websocket/websocket.yaml
@@ -1,0 +1,4 @@
+kind: "Page"
+title: "WebSocket Session Demo"
+form: []
+regions: []

--- a/src/main/resources/cms/site.yaml
+++ b/src/main/resources/cms/site.yaml
@@ -2,6 +2,8 @@ kind: "Site"
 apis:
   - "asset"
   - "com.enonic.app.features:sse"
+  - "com.enonic.app.features:websocket"
+  - "com.enonic.app.features:websocket-public"
 processors:
   - name: "bgcolor-filter"
     order: 10

--- a/src/main/resources/import/features/websocket/_/node.xml
+++ b/src/main/resources/import/features/websocket/_/node.xml
@@ -1,0 +1,169 @@
+<node>
+    <id>5b1c8d2e-9f3a-4e7b-a6c0-4d8e2f1b7a9c</id>
+    <childOrder>modifiedtime DESC</childOrder>
+    <nodeType>content</nodeType>
+    <timestamp>2026-06-05T10:00:00.000Z</timestamp>
+    <inheritPermissions>true</inheritPermissions>
+    <permissions>
+        <principal key="role:system.everyone">
+            <allow type="array">
+                <value>READ</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:system.admin">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.admin">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+    </permissions>
+    <data>
+        <boolean name="valid">true</boolean>
+        <string name="displayName">WebSocket</string>
+        <string name="type">com.enonic.app.features:landing-page</string>
+        <string name="owner">user:system:su</string>
+        <dateTime name="modifiedTime">2026-06-05T10:00:00.000Z</dateTime>
+        <string name="modifier">user:system:su</string>
+        <string name="creator">user:system:su</string>
+        <dateTime name="createdTime">2026-06-05T10:00:00.000Z</dateTime>
+        <property-set name="publish">
+            <dateTime isNull="true" name="first"/>
+            <dateTime isNull="true" name="from"/>
+            <dateTime isNull="true" name="to"/>
+        </property-set>
+        <property-set name="data"/>
+        <property-set name="x">
+            <property-set name="com-enonic-app-features">
+                <property-set name="all-except-folders"/>
+            </property-set>
+        </property-set>
+        <property-set name="components">
+            <string name="type">page</string>
+            <string name="path">/</string>
+            <property-set name="page">
+                <string name="descriptor">com.enonic.app.features:websocket</string>
+                <boolean name="customized">true</boolean>
+                <property-set name="config">
+                    <property-set name="com-enonic-app-features">
+                        <property-set name="websocket"/>
+                    </property-set>
+                </property-set>
+            </property-set>
+        </property-set>
+    </data>
+    <indexConfigs>
+        <analyzer>document_index_default</analyzer>
+        <defaultConfig>
+            <decideByType>true</decideByType>
+            <enabled>true</enabled>
+            <nGram>false</nGram>
+            <fulltext>false</fulltext>
+            <includeInAllText>false</includeInAllText>
+        </defaultConfig>
+        <pathIndexConfigs>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>false</nGram>
+                    <fulltext>false</fulltext>
+                    <includeInAllText>false</includeInAllText>
+                </indexConfig>
+                <path>data.siteConfig.applicationkey</path>
+            </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>false</nGram>
+                    <fulltext>false</fulltext>
+                    <includeInAllText>false</includeInAllText>
+                </indexConfig>
+                <path>components.page.descriptor</path>
+            </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>true</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>false</nGram>
+                    <fulltext>false</fulltext>
+                    <includeInAllText>false</includeInAllText>
+                </indexConfig>
+                <path>x.*</path>
+            </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>false</nGram>
+                    <fulltext>false</fulltext>
+                    <includeInAllText>false</includeInAllText>
+                </indexConfig>
+                <path>type</path>
+            </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>false</enabled>
+                    <nGram>false</nGram>
+                    <fulltext>false</fulltext>
+                    <includeInAllText>false</includeInAllText>
+                </indexConfig>
+                <path>site</path>
+            </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>true</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>false</nGram>
+                    <fulltext>false</fulltext>
+                    <includeInAllText>false</includeInAllText>
+                </indexConfig>
+                <path>data</path>
+            </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>false</enabled>
+                    <nGram>false</nGram>
+                    <fulltext>false</fulltext>
+                    <includeInAllText>false</includeInAllText>
+                </indexConfig>
+                <path>components</path>
+            </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
+        </pathIndexConfigs>
+        <allTextIndexConfig/>
+    </indexConfigs>
+</node>

--- a/src/main/resources/lib/ws-demo.ts
+++ b/src/main/resources/lib/ws-demo.ts
@@ -1,0 +1,12 @@
+import * as websocket from '/lib/xp/websocket';
+import type {WebSocketEvent} from '@enonic-types/core';
+
+export function handleEvent(event: WebSocketEvent<{mode: string}>): void {
+    if (event.type === 'open') {
+        const user = event.session.user ? event.session.user.key : 'anonymous';
+        websocket.send(event.session.id, 'connected, mode=' + event.data.mode + ', user=' + user);
+
+    } else if (event.type === 'message') {
+        websocket.send(event.session.id, 'echo: ' + event.message);
+    }
+}


### PR DESCRIPTION
Added `websocket` page with four sockets demoing `terminateOnSessionExit`, `sessionAccess` and `sessionAccessThrottleMs` Added `websocket` API (authenticated-only) and `websocket-public` API Added `WebSocket` landing page to features content import Bumped `xpVersion` to 8.1.0-SNAPSHOT for the XP branch build