### PR TITLE
Add lib-markdown demo part #260

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ dependencies {
     include libs.mustache
     include libs.text.encoding
     include libs.asset
+    include libs.markdown
     include "com.enonic.xp:lib-sse:${xpVersion}"
 
     testImplementation "com.enonic.xp:testing:${xpVersion}"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,6 +4,7 @@ http-client = "4.0.0"
 thymeleaf = "3.0.0"
 mustache = "3.0.0"
 text-encoding = "3.0.0"
+markdown = "2.0.0"
 junit-bom = "6.1.0"
 
 [libraries]
@@ -12,6 +13,7 @@ http-client = { module = "com.enonic.lib:lib-http-client", version.ref = "http-c
 thymeleaf = { module = "com.enonic.lib:lib-thymeleaf", version.ref = "thymeleaf" }
 mustache = { module = "com.enonic.lib:lib-mustache", version.ref = "mustache" }
 text-encoding = { module = "com.enonic.lib:lib-text-encoding", version.ref = "text-encoding" }
+markdown = { module = "com.enonic.lib:lib-markdown", version.ref = "markdown" }
 junit-bom = { module = "org.junit:junit-bom", version.ref = "junit-bom" }
 junit-jupiter = { module = "org.junit.jupiter:junit-jupiter" }
 junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher" }

--- a/src/main/resources/cms/parts/markdown/markdown.html
+++ b/src/main/resources/cms/parts/markdown/markdown.html
@@ -1,24 +1,66 @@
 <div class="markdown-part">
     <h2>Markdown Lib Demo</h2>
 
-    <form action="#" data-th-action="${postUrl}" method="post">
-        <fieldset>
-            <p>
-                <label>Markdown source</label><br/>
-                <textarea name="source" data-th-utext="${source}" rows="20" style="width: 600px; font-family: monospace;"></textarea>
-            </p>
+    <p>
+        Interactive sandbox plus a fixed set of demo cases covering the features and edge cases of
+        <code>com.enonic.lib:lib-markdown</code>.
+    </p>
 
-            <p>
-                <button type="submit">Render</button>
-            </p>
-        </fieldset>
-    </form>
+    <section id="interactive">
+        <h3>Interactive sandbox</h3>
+        <form action="#" data-th-action="${postUrl}" method="post">
+            <fieldset>
+                <p>
+                    <label>Markdown source</label><br/>
+                    <textarea name="source" data-th-utext="${source}" rows="20"
+                              style="width: 600px; font-family: monospace;"></textarea>
+                </p>
+
+                <p>
+                    <button type="submit">Render</button>
+                </p>
+            </fieldset>
+        </form>
+
+        <h4>Rendered HTML (raw)</h4>
+        <pre data-th-text="${rendered}" style="background:#f4f4f4; padding:10px; white-space: pre-wrap;"></pre>
+
+        <h4>Rendered HTML (live)</h4>
+        <div class="markdown-output" data-th-utext="${rendered}"></div>
+    </section>
 
     <hr/>
 
-    <h3>Rendered HTML (raw)</h3>
-    <pre data-th-text="${rendered}" style="background:#f4f4f4; padding:10px; white-space: pre-wrap;"></pre>
+    <section id="cases">
+        <h3>Use cases</h3>
+        <p>
+            Each case shows a Markdown input and the HTML produced by <code>markdown.render(input)</code>.
+            The <code>lib-markdown</code> 2.0.0 API exposes a single <code>render(string): string</code> function
+            with no configuration options, so behavior here is exactly what plain CommonMark-Java produces.
+        </p>
 
-    <h3>Rendered HTML (live)</h3>
-    <div class="markdown-output" data-th-utext="${rendered}"></div>
+        <div data-th-each="c : ${cases}" data-th-remove="tag">
+            <section data-th-id="'case-' + ${c.key}" class="markdown-case"
+                     style="border-top:1px solid #ccc; padding-top:10px; margin-top:20px;">
+                <h4 data-th-text="${c.title}"></h4>
+                <p class="case-desc" data-th-if="${c.hasDescription}" data-th-text="${c.description}"
+                   style="color:#555;"></p>
+
+                <p><strong>Source</strong></p>
+                <pre data-th-id="'source-' + ${c.key}" class="case-source"
+                     data-th-text="${c.source}"
+                     style="background:#f4f4f4; padding:10px; white-space: pre-wrap;"></pre>
+
+                <p><strong>Rendered HTML (raw)</strong></p>
+                <pre data-th-id="'raw-' + ${c.key}" class="case-raw"
+                     data-th-text="${c.rendered}"
+                     style="background:#eef; padding:10px; white-space: pre-wrap;"></pre>
+
+                <p><strong>Rendered HTML (live)</strong></p>
+                <div data-th-id="'rendered-' + ${c.key}" class="case-rendered"
+                     data-th-utext="${c.rendered}"
+                     style="border:1px dashed #ddd; padding:10px;"></div>
+            </section>
+        </div>
+    </section>
 </div>

--- a/src/main/resources/cms/parts/markdown/markdown.html
+++ b/src/main/resources/cms/parts/markdown/markdown.html
@@ -1,0 +1,24 @@
+<div class="markdown-part">
+    <h2>Markdown Lib Demo</h2>
+
+    <form action="#" data-th-action="${postUrl}" method="post">
+        <fieldset>
+            <p>
+                <label>Markdown source</label><br/>
+                <textarea name="source" data-th-utext="${source}" rows="20" style="width: 600px; font-family: monospace;"></textarea>
+            </p>
+
+            <p>
+                <button type="submit">Render</button>
+            </p>
+        </fieldset>
+    </form>
+
+    <hr/>
+
+    <h3>Rendered HTML (raw)</h3>
+    <pre data-th-text="${rendered}" style="background:#f4f4f4; padding:10px; white-space: pre-wrap;"></pre>
+
+    <h3>Rendered HTML (live)</h3>
+    <div class="markdown-output" data-th-utext="${rendered}"></div>
+</div>

--- a/src/main/resources/cms/parts/markdown/markdown.ts
+++ b/src/main/resources/cms/parts/markdown/markdown.ts
@@ -3,18 +3,193 @@ import * as thymeleaf from '/lib/thymeleaf';
 import * as markdown from '/lib/markdown';
 import type {Request} from '@enonic-types/core';
 
-const SAMPLE = [
+interface DemoCase {
+    key: string;
+    title: string;
+    description?: string;
+    source: string;
+}
+
+const LARGE_DOC = [
+    '# Library reference',
+    '',
+    '*A multi-section example used to verify large input does not break the renderer.*',
+    '',
+    '## Section 1 — Introduction',
+    '',
+    'Paragraph one with a [link](https://example.com) and an autolink: <https://enonic.com>.',
+    '',
+    '## Section 2 — Lists',
+    '',
+    '1. First',
+    '2. Second',
+    '   - nested',
+    '3. Third',
+    '',
+    '## Section 3 — Code',
+    '',
+    '```bash',
+    'curl -s http://localhost:8080/site/default/draft/features/markdown',
+    '```',
+    '',
+    '## Section 4 — Quote',
+    '',
+    '> A closing block quote.',
+    ''
+].join('\n');
+
+const CASES: DemoCase[] = [
+    {
+        key: 'headings',
+        title: 'Headings (ATX and Setext)',
+        source: [
+            '# H1 ATX heading',
+            '## H2 ATX heading',
+            '### H3 ATX heading',
+            '',
+            'Setext H1 heading',
+            '=================',
+            '',
+            'Setext H2 heading',
+            '-----------------'
+        ].join('\n')
+    },
+    {
+        key: 'emphasis',
+        title: 'Emphasis: bold, italic, and inline code',
+        source: '**MD_BOLD**, *MD_ITAL*, ***MD_BOTH*** and `MD_CODE()`.'
+    },
+    {
+        key: 'lists',
+        title: 'Lists: ordered, unordered, nested',
+        source: [
+            '- alpha',
+            '- beta',
+            '  - beta one',
+            '  - beta two',
+            '    1. ordered nested',
+            '    2. second ordered',
+            '- gamma'
+        ].join('\n')
+    },
+    {
+        key: 'code-block-lang',
+        title: 'Fenced code block with language hint',
+        source: [
+            '```javascript',
+            "var lib = require('/lib/markdown');",
+            "lib.render('MD_FENCE');",
+            '```'
+        ].join('\n')
+    },
+    {
+        key: 'links',
+        title: 'Links, autolinks, and images',
+        source:
+            'A [MD_LINK](https://example.com), an autolink <https://enonic.com> ' +
+            'and an image ![MD_IMG](/p.png "MD_TITLE").'
+    },
+    {
+        key: 'block-quote',
+        title: 'Block quote (nested)',
+        source: [
+            '> outer quote line',
+            '> > nested quote line'
+        ].join('\n')
+    },
+    {
+        key: 'gfm-table',
+        title: 'GFM table — CommonMark passthrough',
+        description:
+            'lib-markdown 2.0.0 wires plain CommonMark-Java with no GFM extensions, ' +
+            'so a pipe table is rendered as a paragraph instead of an HTML <table>.',
+        source: [
+            '| MD_COL1 | MD_COL2 |',
+            '| ------- | ------- |',
+            '| MD_VAL1 | MD_VAL2 |'
+        ].join('\n')
+    },
+    {
+        key: 'gfm-tasklist',
+        title: 'GFM task list — CommonMark passthrough',
+        description:
+            'Without the task-list-items extension the brackets stay literal inside the list item.',
+        source: [
+            '- [x] MD_TASK_DONE',
+            '- [ ] MD_TASK_TODO'
+        ].join('\n')
+    },
+    {
+        key: 'gfm-strike',
+        title: 'GFM strikethrough — CommonMark passthrough',
+        description:
+            'Tildes are kept literal because the strikethrough extension is not enabled.',
+        source: 'A ~~MD_STRIKE~~ word.'
+    },
+    {
+        key: 'raw-html',
+        title: 'Raw HTML passthrough (no sanitization)',
+        description:
+            'CommonMark forwards raw block-level HTML unchanged; the renderer is not configured ' +
+            'with escapeHtml(true), so attributes and tags survive.',
+        source: [
+            '<div class="MD_RAW_HTML">',
+            '  <span style="color: red;">MD_RAW_INNER</span>',
+            '</div>'
+        ].join('\n')
+    },
+    {
+        key: 'hrule',
+        title: 'Horizontal rule',
+        source: [
+            'paragraph above',
+            '',
+            '---',
+            '',
+            'paragraph below'
+        ].join('\n')
+    },
+    {
+        key: 'linebreak',
+        title: 'Hard line break via trailing backslash',
+        description: 'A trailing backslash forces a <br /> within a paragraph.',
+        source: 'MD_LINEBREAK_A\\\nMD_LINEBREAK_B'
+    },
+    {
+        key: 'empty',
+        title: 'Empty input',
+        description: 'The render function returns an empty string and does not throw.',
+        source: ''
+    },
+    {
+        key: 'large',
+        title: 'Large multi-section document',
+        description: 'Exercises multiple constructs together to verify the renderer handles non-trivial input.',
+        source: LARGE_DOC
+    }
+];
+
+function buildRenderedCases() {
+    return CASES.map(c => ({
+        key: c.key,
+        title: c.title,
+        description: c.description || '',
+        hasDescription: !!c.description,
+        source: c.source,
+        rendered: markdown.render(c.source)
+    }));
+}
+
+const INTERACTIVE_DEFAULT = [
     '# Markdown Lib Demo',
     '',
-    'This part renders a sample document through `com.enonic.lib:lib-markdown`.',
+    'Type Markdown into the form below to render it through `com.enonic.lib:lib-markdown`.',
     '',
     '## Features',
     '',
     '- **Bold**, *italic* and `inline code`',
     '- Ordered and unordered lists',
     '- [Links](https://developer.enonic.com)',
-    '',
-    '## Code block',
     '',
     '```javascript',
     "var lib = require('/lib/markdown');",
@@ -26,11 +201,11 @@ const SAMPLE = [
 ].join('\n');
 
 export const GET = function (req: Request) {
-    return renderPage(SAMPLE);
+    return renderPage(INTERACTIVE_DEFAULT);
 };
 
 export const POST = function (req: Request) {
-    const source = (req.params.source as string) ?? SAMPLE;
+    const source = (req.params.source as string) ?? INTERACTIVE_DEFAULT;
     return renderPage(source);
 };
 
@@ -38,7 +213,8 @@ function renderPage(source: string) {
     const params = {
         postUrl: portal.componentUrl({}),
         source: source,
-        rendered: markdown.render(source)
+        rendered: markdown.render(source),
+        cases: buildRenderedCases()
     };
 
     const view = resolve('markdown.html');

--- a/src/main/resources/cms/parts/markdown/markdown.ts
+++ b/src/main/resources/cms/parts/markdown/markdown.ts
@@ -1,0 +1,51 @@
+import * as portal from '/lib/xp/portal';
+import * as thymeleaf from '/lib/thymeleaf';
+import * as markdown from '/lib/markdown';
+import type {Request} from '@enonic-types/core';
+
+const SAMPLE = [
+    '# Markdown Lib Demo',
+    '',
+    'This part renders a sample document through `com.enonic.lib:lib-markdown`.',
+    '',
+    '## Features',
+    '',
+    '- **Bold**, *italic* and `inline code`',
+    '- Ordered and unordered lists',
+    '- [Links](https://developer.enonic.com)',
+    '',
+    '## Code block',
+    '',
+    '```javascript',
+    "var lib = require('/lib/markdown');",
+    "lib.render('Hello **World**');",
+    '```',
+    '',
+    '> Block quotes work too.',
+    ''
+].join('\n');
+
+export const GET = function (req: Request) {
+    return renderPage(SAMPLE);
+};
+
+export const POST = function (req: Request) {
+    const source = (req.params.source as string) ?? SAMPLE;
+    return renderPage(source);
+};
+
+function renderPage(source: string) {
+    const params = {
+        postUrl: portal.componentUrl({}),
+        source: source,
+        rendered: markdown.render(source)
+    };
+
+    const view = resolve('markdown.html');
+    const body = thymeleaf.render(view, params);
+
+    return {
+        contentType: 'text/html',
+        body: body
+    };
+}

--- a/src/main/resources/cms/parts/markdown/markdown.yaml
+++ b/src/main/resources/cms/parts/markdown/markdown.yaml
@@ -1,0 +1,4 @@
+kind: "Part"
+title: "Markdown Lib example"
+description: "Renders a sample Markdown document via lib-markdown."
+form: [ ]

--- a/src/main/resources/import/features/markdown/_/node.xml
+++ b/src/main/resources/import/features/markdown/_/node.xml
@@ -1,0 +1,171 @@
+<node>
+    <id>d8b51a7e-8a72-4b1c-9f2a-3c4d5e6f7890</id>
+    <childOrder>modifiedtime DESC</childOrder>
+    <nodeType>content</nodeType>
+    <timestamp>2026-06-30T12:00:00.000Z</timestamp>
+    <inheritPermissions>true</inheritPermissions>
+    <permissions>
+        <principal key="user:system:anonymous">
+            <allow type="array">
+                <value>READ</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:system.authenticated">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.admin">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:system.everyone">
+            <allow type="array">
+                <value>READ</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+    </permissions>
+    <data>
+        <boolean name="valid">true</boolean>
+        <string name="displayName">markdown</string>
+        <string name="type">com.enonic.app.features:landing-page</string>
+        <string name="owner">user:system:su</string>
+        <dateTime name="modifiedTime">2026-06-30T12:00:00.000Z</dateTime>
+        <string name="modifier">user:system:su</string>
+        <string name="creator">user:system:su</string>
+        <dateTime name="createdTime">2026-06-30T12:00:00.000Z</dateTime>
+        <property-set name="data"/>
+        <property-set name="components">
+            <string name="type">page</string>
+            <string name="path">/</string>
+            <property-set name="page">
+                <string name="descriptor">com.enonic.app.features:default</string>
+                <boolean name="customized">true</boolean>
+            </property-set>
+        </property-set>
+        <property-set name="components">
+            <string name="type">part</string>
+            <string name="path">/main/0</string>
+            <property-set name="part">
+                <string name="descriptor">com.enonic.app.features:markdown</string>
+                <property-set name="config">
+                    <property-set name="com-enonic-app-features">
+                        <property-set name="markdown"/>
+                    </property-set>
+                </property-set>
+            </property-set>
+        </property-set>
+    </data>
+    <indexConfigs>
+        <defaultConfig>
+            <decideByType>true</decideByType>
+            <enabled>true</enabled>
+            <nGram>false</nGram>
+            <fulltext>false</fulltext>
+            <includeInAllText>false</includeInAllText>
+        </defaultConfig>
+        <pathIndexConfigs>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>true</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>false</nGram>
+                    <fulltext>false</fulltext>
+                    <includeInAllText>false</includeInAllText>
+                </indexConfig>
+                <path>components.part.config.com-enonic-app-features.markdown.*</path>
+            </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>false</nGram>
+                    <fulltext>false</fulltext>
+                    <includeInAllText>false</includeInAllText>
+                </indexConfig>
+                <path>components.part.descriptor</path>
+            </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>false</nGram>
+                    <fulltext>false</fulltext>
+                    <includeInAllText>false</includeInAllText>
+                </indexConfig>
+                <path>components.page.template</path>
+            </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>false</nGram>
+                    <fulltext>false</fulltext>
+                    <includeInAllText>false</includeInAllText>
+                </indexConfig>
+                <path>components.page.descriptor</path>
+            </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>false</nGram>
+                    <fulltext>false</fulltext>
+                    <includeInAllText>false</includeInAllText>
+                </indexConfig>
+                <path>components.page.customized</path>
+            </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>true</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>false</nGram>
+                    <fulltext>false</fulltext>
+                    <includeInAllText>false</includeInAllText>
+                </indexConfig>
+                <path>data</path>
+            </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>false</enabled>
+                    <nGram>false</nGram>
+                    <fulltext>false</fulltext>
+                    <includeInAllText>false</includeInAllText>
+                </indexConfig>
+                <path>components</path>
+            </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
+        </pathIndexConfigs>
+        <allTextIndexConfig/>
+    </indexConfigs>
+</node>

--- a/src/main/resources/tsconfig.json
+++ b/src/main/resources/tsconfig.json
@@ -25,6 +25,9 @@
       "/lib/mustache": [
         "./types/mustache"
       ],
+      "/lib/markdown": [
+        "./types/markdown"
+      ],
       "/*": [
         "./*"
       ]

--- a/src/main/resources/types/markdown.d.ts
+++ b/src/main/resources/types/markdown.d.ts
@@ -1,0 +1,5 @@
+declare module '/lib/markdown' {
+    export function render(markdown: string): string;
+}
+
+export {};

--- a/tsup/server.ts
+++ b/tsup/server.ts
@@ -57,6 +57,7 @@ export default function buildServerConfig(): Options {
       '/lib/graphql-connection',
       '/lib/http-client',
       '/lib/license',
+      '/lib/markdown',
       '/lib/mustache',
       '/lib/router',
       '/lib/util',


### PR DESCRIPTION
Adds `com.enonic.lib:lib-markdown:2.0.0` (latest released) as a bundled dependency and ships a new part at `cms/parts/markdown/` that exercises it. The view renders a sample document covering headings, bold/italic, inline code, code blocks, links, lists and a block quote, and shows the produced HTML both as raw text and as a live fragment so the part doubles as a smoke test of the library.

Wired through the existing pattern used by other libs: `markdown` version + library declarations in `gradle/libs.versions.toml`, `include libs.markdown` in `build.gradle`, an `external` entry in `tsup/server.ts`, a local `types/markdown.d.ts` module declaration plus a `paths` mapping in the source `tsconfig.json`.

`./gradlew build` is green locally; the resulting jar contains `lib/markdown.js`, `com.enonic.lib.markdown.MarkdownService` and the bundled `commonmark` classes.

Closes #260

<sub>*Drafted with AI assistance*</sub>