### PR TITLE
Add demo exercising lib-cors 2.0.0 #276

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ dependencies {
     include xplibs.auditlog
     include xplibs.project
     include xplibs.export
+    include libs.cors
     include libs.http.client
     include libs.thymeleaf
     include libs.mustache

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,6 @@
 [versions]
 asset = "2.0.0"
+cors = "2.0.0"
 http-client = "4.0.0"
 thymeleaf = "3.0.0"
 mustache = "3.0.0"
@@ -8,6 +9,7 @@ junit-bom = "6.1.1"
 
 [libraries]
 asset = { module = "com.enonic.lib:lib-asset", version.ref = "asset" }
+cors = { module = "com.enonic.lib:lib-cors", version.ref = "cors" }
 http-client = { module = "com.enonic.lib:lib-http-client", version.ref = "http-client" }
 thymeleaf = { module = "com.enonic.lib:lib-thymeleaf", version.ref = "thymeleaf" }
 mustache = { module = "com.enonic.lib:lib-mustache", version.ref = "mustache" }

--- a/src/main/resources/cms/site.yaml
+++ b/src/main/resources/cms/site.yaml
@@ -12,6 +12,10 @@ processors:
   - name: "app-header-filter"
     order: 10
 mappings:
+  - controller: "/services/cors/cors.js"
+    order: 40
+    invertPattern: false
+    pattern: "/cors-demo"
   - controller: "/cms/mappings/controller.js"
     order: 50
     invertPattern: false

--- a/src/main/resources/services/cors/cors.ts
+++ b/src/main/resources/services/cors/cors.ts
@@ -1,0 +1,70 @@
+import * as corsLib from '/lib/enonic/cors';
+import type {Request} from '@enonic-types/core';
+
+type CorsConfig = Record<string, string | undefined>;
+
+const PROFILES: Record<string, CorsConfig> = {
+    default: {
+        'cors.origin': 'https://example.test, https://allowed.test',
+        'cors.credentials': 'true',
+        'cors.allowedHeaders': 'Content-Type, Authorization, X-Demo',
+        'cors.methods': 'GET, POST, PUT, DELETE',
+        'cors.exposedHeaders': 'X-Request-Id, X-Demo-Header',
+        'cors.maxAge': '3600'
+    },
+    wildcard: {
+        'cors.origin': '*',
+        'cors.methods': 'GET, POST'
+    },
+    'reflect-any': {
+        'cors.origin': '~.*',
+        'cors.credentials': 'true'
+    },
+    'regex-subdomain': {
+        'cors.origin': '~https://.*\\.example\\.test'
+    },
+    disabled: {}
+};
+
+function profileName(req: Request): string {
+    return (req.params.profile as string) || 'default';
+}
+
+function pickConfig(req: Request): CorsConfig {
+    const name = profileName(req);
+    return PROFILES[name] || PROFILES.default;
+}
+
+function handleGet(req: Request) {
+    const name = profileName(req);
+    // 'app-config' profile exercises the convenience wrapper that reads from app.config.
+    const headers = name === 'app-config'
+        ? corsLib.getHeaders(req)
+        : corsLib.resolveHeaders(pickConfig(req), req);
+    return {
+        status: 200,
+        contentType: 'application/json',
+        headers: {
+            ...headers,
+            'X-Request-Id': 'demo-' + Date.now(),
+            'X-Demo-Header': 'cors-demo'
+        },
+        body: {
+            profile: name,
+            method: req.method,
+            origin: req.headers['Origin'] || null,
+            corsHeaders: headers
+        }
+    };
+}
+
+function handleOptions(req: Request) {
+    const name = profileName(req);
+    return name === 'app-config'
+        ? corsLib.respondOptions(req)
+        : corsLib.resolveOptionsResponse(pickConfig(req), req);
+}
+
+export {handleGet as GET};
+export {handleGet as POST};
+export {handleOptions as OPTIONS};

--- a/src/main/resources/tsconfig.json
+++ b/src/main/resources/tsconfig.json
@@ -13,6 +13,9 @@
       "/lib/enonic/asset": [
         "../../../node_modules/@enonic-types/lib-asset"
       ],
+      "/lib/enonic/cors": [
+        "./types/cors"
+      ],
       "/lib/thymeleaf": [
         "./types/thymeleaf"
       ],

--- a/src/main/resources/types/cors.d.ts
+++ b/src/main/resources/types/cors.d.ts
@@ -1,0 +1,17 @@
+declare module '/lib/enonic/cors' {
+    import type {Request} from '@enonic-types/core';
+
+    type CorsConfig = Record<string, string | undefined>;
+    type CorsHeaders = Record<string, string>;
+    type CorsResponse = {
+        status: number;
+        headers: CorsHeaders;
+    };
+
+    export function resolveHeaders(config: CorsConfig, req: Request): CorsHeaders;
+    export function getHeaders(req: Request): CorsHeaders;
+    export function resolveOptionsResponse(config: CorsConfig, req: Request): CorsResponse;
+    export function respondOptions(req: Request): CorsResponse;
+}
+
+export {};

--- a/tsup/server.ts
+++ b/tsup/server.ts
@@ -51,6 +51,7 @@ export default function buildServerConfig(): Options {
     external: [
       '/lib/cache',
       '/lib/enonic/asset',
+      '/lib/enonic/cors',
       '/lib/enonic/static',
       /^\/lib\/guillotine/,
       '/lib/graphql',


### PR DESCRIPTION
## Summary
- Wire `com.enonic.lib:lib-cors:2.0.0` (latest released).
- New `services/cors/cors.ts` exercising the lib across several profiles selectable via `?profile=…`: `default` (specific allowed origins, credentials, custom methods/headers, expose-headers, max-age), `wildcard` (`*`), `reflect-any` (`~.*` regex w/ credentials), `regex-subdomain` (`~https://.*\.example\.test`), `disabled` (CORS off), and `app-config` (delegates to `getHeaders`/`respondOptions` from `app.config`).
- Site mapping `/cors-demo` → the same controller, so OPTIONS preflight dispatches to lib-cors. `ServiceHandler` intercepts OPTIONS at the platform level (`ServiceHandler.java:68-71`) and never reaches user code via `/_/service/…`.

## E2E (XP 8.0.2 + Content Studio 6.0.2)

Pre-built generic distro from `repo.enonic.com/public`, app rebuilt with `-PxpVersion=8.0.2`. Service URL: `/site/features/draft/features/cors-demo`. All 9 cases pass:

| # | Case | Result |
|---|------|--------|
| 1 | Preflight (OPTIONS), allowed origin — default profile | 204; ACAO, ACAM, ACAH, ACAC, Max-Age, Expose-Headers, Vary all reflect config |
| 2 | GET, allowed origin — default profile | 200; ACAO reflects origin; ACAC=true; Expose-Headers; Vary: Origin |
| 3 | GET, disallowed origin | 200; ACAO/ACAC absent; Vary: Origin retained |
| 4 | GET, wildcard profile | 200; ACAO: `*`; ACAM matches `GET, POST` |
| 5 | GET, reflect-any profile | 200; ACAO reflects any origin; ACAC=true (`~.*` differs from `*` here) |
| 6 | GET, regex-subdomain profile | match → ACAO reflects subdomain; non-match → ACAO absent |
| 7 | GET, disabled profile | 200; no CORS headers |
| 8 | OPTIONS, disallowed method (authed) | 403; ACAO absent |
| 9 | OPTIONS, disallowed headers (authed) | 403; ACAO absent |

Cases 8/9 require auth because XP remaps anon `403` to a `401` login page (`ExceptionRendererImpl.java:256-259`); the lib still emits the correct `{status: 403, headers: {}}`.

Sample observed headers — preflight (OPTIONS, `Origin: https://example.test`, `ACRM: POST`, `ACRH: Content-Type, Authorization`):

```
HTTP/1.1 204 No Content
Access-Control-Allow-Credentials: true
Access-Control-Allow-Headers: Content-Type, Authorization, X-Demo
Access-Control-Allow-Methods: GET, POST, PUT, DELETE
Access-Control-Allow-Origin: https://example.test
Access-Control-Expose-Headers: X-Request-Id, X-Demo-Header
Access-Control-Max-Age: 3600
Vary: Origin
```

Actual GET (`Origin: https://example.test`):

```
HTTP/1.1 200 OK
Content-Type: application/json
Access-Control-Allow-Credentials: true
Access-Control-Allow-Headers: Content-Type, Authorization, X-Demo
Access-Control-Allow-Methods: GET, POST, PUT, DELETE
Access-Control-Allow-Origin: https://example.test
Access-Control-Expose-Headers: X-Request-Id, X-Demo-Header
Vary: Origin
```

Closes #276

<sub>*Drafted with AI assistance*</sub>
