### PR TITLE
GraalJS Compatibility #288

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,7 @@ dependencies {
     testImplementation(platform(libs.junit.bom))
     testImplementation libs.junit.jupiter
     testRuntimeOnly libs.junit.platform.launcher
+    testRuntimeOnly libs.graalvm.js
 }
 
 repositories {
@@ -65,6 +66,18 @@ test {
     useJUnitPlatform {
     }
 }
+
+def testGraalJs = tasks.register('testGraalJs', Test) {
+    group = 'verification'
+    description = 'Runs tests with the GraalJS script engine.'
+    useJUnitPlatform()
+    testClassesDirs = sourceSets.test.output.classesDirs
+    classpath = sourceSets.test.runtimeClasspath
+    systemProperty 'xp.script-engine', 'GraalJS'
+    shouldRunAfter test
+}
+
+check.dependsOn testGraalJs
 
 processResources {
     exclude '**/.gitkeep'

--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,6 @@ dependencies {
     testImplementation(platform(libs.junit.bom))
     testImplementation libs.junit.jupiter
     testRuntimeOnly libs.junit.platform.launcher
-    testRuntimeOnly libs.graalvm.js
 }
 
 repositories {
@@ -67,17 +66,9 @@ test {
     }
 }
 
-def testGraalJs = tasks.register('testGraalJs', Test) {
-    group = 'verification'
-    description = 'Runs tests with the GraalJS script engine.'
-    useJUnitPlatform()
-    testClassesDirs = sourceSets.test.output.classesDirs
-    classpath = sourceSets.test.runtimeClasspath
-    systemProperty 'xp.script-engine', 'GraalJS'
-    shouldRunAfter test
+xp {
+    scriptEngines = ['Nashorn', 'GraalJS']
 }
-
-check.dependsOn testGraalJs
 
 processResources {
     exclude '**/.gitkeep'

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,7 +18,6 @@ recaptcha = "4.0.0"
 qrcode = "3.0.1"
 markdown = "2.0.0"
 junit-bom = "6.1.2"
-graalvm = "25.0.3"
 
 [libraries]
 asset = { module = "com.enonic.lib:lib-asset", version.ref = "asset" }
@@ -42,4 +41,3 @@ markdown = { module = "com.enonic.lib:lib-markdown", version.ref = "markdown" }
 junit-bom = { module = "org.junit:junit-bom", version.ref = "junit-bom" }
 junit-jupiter = { module = "org.junit.jupiter:junit-jupiter" }
 junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher" }
-graalvm-js = { module = "org.graalvm.polyglot:js", version.ref = "graalvm" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,6 +18,7 @@ recaptcha = "4.0.0"
 qrcode = "3.0.1"
 markdown = "2.0.0"
 junit-bom = "6.1.2"
+graalvm = "25.0.3"
 
 [libraries]
 asset = { module = "com.enonic.lib:lib-asset", version.ref = "asset" }
@@ -41,3 +42,4 @@ markdown = { module = "com.enonic.lib:lib-markdown", version.ref = "markdown" }
 junit-bom = { module = "org.junit:junit-bom", version.ref = "junit-bom" }
 junit-jupiter = { module = "org.junit.jupiter:junit-jupiter" }
 junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher" }
+graalvm-js = { module = "org.graalvm.polyglot:js", version.ref = "graalvm" }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id("com.enonic.xp.settings") version "4.1.0"
+    id("com.enonic.xp.settings") version "4.2.0"
 }
 
 rootProject.name = projectName

--- a/src/main/resources/lib/sse.ts
+++ b/src/main/resources/lib/sse.ts
@@ -9,21 +9,9 @@ interface SseMessage {
 
 interface SseLib {
     send(params: { clientId: string; message: SseMessage }): void;
-
-    close(params: { clientId: string }): void;
-
-    isOpen(params: { clientId: string }): boolean;
 }
 
 const sseLib = require('/lib/xp/sse') as SseLib;
-
-const MESSAGES = [
-    'Thinking...',
-    'Loading...',
-    'Working...',
-    'Almost there...',
-    'Done!'
-];
 
 export function getResponse() {
     return {sse: {}};
@@ -35,14 +23,8 @@ export function handleEvent(event: { type: string; clientId: string }, descripti
     }
     const clientId = event.clientId;
     sseLib.send({clientId, message: {event: 'message', data: 'Hello!'}});
-    taskLib.executeFunction({
-        description: descriptionPrefix + clientId,
-        func: function () {
-            for (let i = 0; i < MESSAGES.length && sseLib.isOpen({clientId}); i++) {
-                taskLib.sleep(1000);
-                sseLib.send({clientId, message: {event: 'message', data: MESSAGES[i]}});
-            }
-            sseLib.close({clientId});
-        }
+    taskLib.submitTask({
+        descriptor: 'sse-drip',
+        config: {clientId, descriptionPrefix}
     });
 }

--- a/src/main/resources/services/task/task.ts
+++ b/src/main/resources/services/task/task.ts
@@ -1,34 +1,8 @@
 import * as taskLib from '/lib/xp/task';
-import type {Request} from '@enonic-types/core';
 
-function handleGet(req: Request) {
-    const steps = ['one', 'two', 'three'];
-
-    const taskId = taskLib.executeFunction({
-        description: 'my test',
-        func: function () {
-            log.info('Hello! ');
-
-            for (let i = 0; i < steps.length; i++) {
-                taskLib.sleep(1000);
-
-                taskLib.progress({
-                    info: 'Step ' + steps[i],
-                    current: i + 1,
-                    total: steps.length
-                });
-
-                const task = taskLib.get(taskId);
-                log.info(JSON.stringify(task, null, 4));
-            }
-
-            const tasks = taskLib.list();
-            log.info(JSON.stringify(tasks, null, 4));
-
-            taskLib.progress({
-                info: 'Done!'
-            });
-        }
+export function GET() {
+    const taskId = taskLib.submitTask({
+        descriptor: 'progress-demo'
     });
 
     return {
@@ -36,5 +10,3 @@ function handleGet(req: Request) {
         body: 'Task submitted: ' + taskId
     };
 }
-
-export {handleGet as GET};

--- a/src/main/resources/tasks/progress-demo/progress-demo.ts
+++ b/src/main/resources/tasks/progress-demo/progress-demo.ts
@@ -1,0 +1,27 @@
+import * as taskLib from '/lib/xp/task';
+
+const STEPS = ['one', 'two', 'three'];
+
+export function run(_config: Record<string, unknown>, taskId: string): void {
+    log.info('Hello! ');
+
+    for (let i = 0; i < STEPS.length; i++) {
+        taskLib.sleep(1000);
+
+        taskLib.progress({
+            info: 'Step ' + STEPS[i],
+            current: i + 1,
+            total: STEPS.length
+        });
+
+        const task = taskLib.get(taskId);
+        log.info(JSON.stringify(task, null, 4));
+    }
+
+    const tasks = taskLib.list();
+    log.info(JSON.stringify(tasks, null, 4));
+
+    taskLib.progress({
+        info: 'Done!'
+    });
+}

--- a/src/main/resources/tasks/progress-demo/progress-demo.yaml
+++ b/src/main/resources/tasks/progress-demo/progress-demo.yaml
@@ -1,0 +1,3 @@
+kind: "Task"
+description: "Reports progress through a few steps"
+form: [ ]

--- a/src/main/resources/tasks/sse-drip/sse-drip.ts
+++ b/src/main/resources/tasks/sse-drip/sse-drip.ts
@@ -1,0 +1,34 @@
+import * as taskLib from '/lib/xp/task';
+
+interface SseLib {
+    send(params: { clientId: string; message: { event?: string; data?: string } }): void;
+
+    close(params: { clientId: string }): void;
+
+    isOpen(params: { clientId: string }): boolean;
+}
+
+const sseLib = require('/lib/xp/sse') as SseLib;
+
+const MESSAGES = [
+    'Thinking...',
+    'Loading...',
+    'Working...',
+    'Almost there...',
+    'Done!'
+];
+
+interface SseDripConfig {
+    clientId: string;
+    descriptionPrefix: string;
+}
+
+export function run(config: SseDripConfig): void {
+    const {clientId, descriptionPrefix} = config;
+    log.info('SSE drip started: ' + descriptionPrefix + clientId);
+    for (let i = 0; i < MESSAGES.length && sseLib.isOpen({clientId}); i++) {
+        taskLib.sleep(1000);
+        sseLib.send({clientId, message: {event: 'message', data: MESSAGES[i]}});
+    }
+    sseLib.close({clientId});
+}

--- a/src/main/resources/tasks/sse-drip/sse-drip.yaml
+++ b/src/main/resources/tasks/sse-drip/sse-drip.yaml
@@ -1,0 +1,3 @@
+kind: "Task"
+description: "Drip-feeds messages to one SSE client"
+form: [ ]

--- a/src/test/java/com/enonic/guide/ProgressDemoTaskTest.java
+++ b/src/test/java/com/enonic/guide/ProgressDemoTaskTest.java
@@ -1,0 +1,13 @@
+package com.enonic.guide;
+
+import com.enonic.xp.testing.ScriptRunnerSupport;
+
+public class ProgressDemoTaskTest
+    extends ScriptRunnerSupport
+{
+    @Override
+    public String getScriptTestFile()
+    {
+        return "/tasks/progress-demo/progress-demo-test.js";
+    }
+}

--- a/src/test/java/com/enonic/guide/SseDripTaskTest.java
+++ b/src/test/java/com/enonic/guide/SseDripTaskTest.java
@@ -1,0 +1,13 @@
+package com.enonic.guide;
+
+import com.enonic.xp.testing.ScriptRunnerSupport;
+
+public class SseDripTaskTest
+    extends ScriptRunnerSupport
+{
+    @Override
+    public String getScriptTestFile()
+    {
+        return "/tasks/sse-drip/sse-drip-test.js";
+    }
+}

--- a/src/test/java/com/enonic/guide/SseLibTest.java
+++ b/src/test/java/com/enonic/guide/SseLibTest.java
@@ -1,0 +1,13 @@
+package com.enonic.guide;
+
+import com.enonic.xp.testing.ScriptRunnerSupport;
+
+public class SseLibTest
+    extends ScriptRunnerSupport
+{
+    @Override
+    public String getScriptTestFile()
+    {
+        return "/lib/sse-test.js";
+    }
+}

--- a/src/test/java/com/enonic/guide/TaskServiceTest.java
+++ b/src/test/java/com/enonic/guide/TaskServiceTest.java
@@ -1,0 +1,13 @@
+package com.enonic.guide;
+
+import com.enonic.xp.testing.ScriptRunnerSupport;
+
+public class TaskServiceTest
+    extends ScriptRunnerSupport
+{
+    @Override
+    public String getScriptTestFile()
+    {
+        return "/services/task/task-test.js";
+    }
+}

--- a/src/test/resources/lib/sse-test.js
+++ b/src/test/resources/lib/sse-test.js
@@ -1,0 +1,43 @@
+var t = require('/lib/xp/testing');
+
+var sent = [];
+var submitted = [];
+
+t.mock('/lib/xp/sse.js', {
+    send: function (params) {
+        sent.push(params);
+    }
+});
+
+t.mock('/lib/xp/task.js', {
+    submitTask: function (params) {
+        submitted.push(params);
+        return 'task-id-7';
+    }
+});
+
+exports.testOpenSubmitsDripTask = function () {
+    sent = [];
+    submitted = [];
+
+    var lib = require('/lib/sse');
+    lib.handleEvent({type: 'open', clientId: 'client-9'}, 'sse-demo-');
+
+    t.assertEquals(1, sent.length);
+    t.assertEquals('Hello!', sent[0].message.data);
+    t.assertEquals(1, submitted.length);
+    t.assertEquals('sse-drip', submitted[0].descriptor);
+    t.assertEquals('client-9', submitted[0].config.clientId);
+    t.assertEquals('sse-demo-', submitted[0].config.descriptionPrefix);
+};
+
+exports.testNonOpenEventIgnored = function () {
+    sent = [];
+    submitted = [];
+
+    var lib = require('/lib/sse');
+    lib.handleEvent({type: 'close', clientId: 'client-9'}, 'sse-demo-');
+
+    t.assertEquals(0, sent.length);
+    t.assertEquals(0, submitted.length);
+};

--- a/src/test/resources/services/task/task-test.js
+++ b/src/test/resources/services/task/task-test.js
@@ -1,0 +1,22 @@
+var t = require('/lib/xp/testing');
+
+var submitted = [];
+
+t.mock('/lib/xp/task.js', {
+    submitTask: function (params) {
+        submitted.push(params);
+        return 'task-id-42';
+    }
+});
+
+exports.testGetSubmitsNamedTask = function () {
+    submitted = [];
+
+    var service = require('./task');
+    var result = service.GET();
+
+    t.assertEquals('text/plain', result.contentType);
+    t.assertEquals('Task submitted: task-id-42', result.body);
+    t.assertEquals(1, submitted.length);
+    t.assertEquals('progress-demo', submitted[0].descriptor);
+};

--- a/src/test/resources/tasks/progress-demo/progress-demo-test.js
+++ b/src/test/resources/tasks/progress-demo/progress-demo-test.js
@@ -1,0 +1,52 @@
+var t = require('/lib/xp/testing');
+
+var progressCalls = [];
+var getCalls = [];
+var listCalled = 0;
+
+t.mock('/lib/xp/task.js', {
+    sleep: function () {
+    },
+    progress: function (params) {
+        progressCalls.push(params);
+    },
+    get: function (taskId) {
+        getCalls.push(taskId);
+        return {id: taskId, state: 'RUNNING'};
+    },
+    list: function () {
+        listCalled++;
+        return [];
+    }
+});
+
+exports.testProgressReportedForEachStep = function () {
+    progressCalls = [];
+    getCalls = [];
+    listCalled = 0;
+
+    var task = require('./progress-demo');
+    task.run({}, 'task-abc');
+
+    t.assertEquals(4, progressCalls.length);
+    t.assertEquals('Step one', progressCalls[0].info);
+    t.assertEquals(1, progressCalls[0].current);
+    t.assertEquals(3, progressCalls[0].total);
+    t.assertEquals('Step three', progressCalls[2].info);
+    t.assertEquals(3, progressCalls[2].current);
+    t.assertEquals('Done!', progressCalls[3].info);
+};
+
+exports.testTaskIdComesFromContext = function () {
+    progressCalls = [];
+    getCalls = [];
+    listCalled = 0;
+
+    var task = require('./progress-demo');
+    task.run({}, 'task-xyz');
+
+    t.assertEquals(3, getCalls.length);
+    t.assertEquals('task-xyz', getCalls[0]);
+    t.assertEquals('task-xyz', getCalls[2]);
+    t.assertEquals(1, listCalled);
+};

--- a/src/test/resources/tasks/sse-drip/sse-drip-test.js
+++ b/src/test/resources/tasks/sse-drip/sse-drip-test.js
@@ -1,0 +1,55 @@
+var t = require('/lib/xp/testing');
+
+var sent = [];
+var closed = [];
+var openResponses = null;
+
+t.mock('/lib/xp/sse.js', {
+    send: function (params) {
+        sent.push(params);
+    },
+    close: function (params) {
+        closed.push(params);
+    },
+    isOpen: function () {
+        if (openResponses === null) {
+            return true;
+        }
+        return openResponses.length > 0 ? openResponses.shift() : false;
+    }
+});
+
+t.mock('/lib/xp/task.js', {
+    sleep: function () {
+    }
+});
+
+exports.testDripSendsAllMessages = function () {
+    sent = [];
+    closed = [];
+    openResponses = null;
+
+    var task = require('./sse-drip');
+    task.run({clientId: 'client-1', descriptionPrefix: 'sse-demo-'});
+
+    t.assertEquals(5, sent.length);
+    t.assertEquals('client-1', sent[0].clientId);
+    t.assertEquals('message', sent[0].message.event);
+    t.assertEquals('Thinking...', sent[0].message.data);
+    t.assertEquals('Done!', sent[4].message.data);
+    t.assertEquals(1, closed.length);
+    t.assertEquals('client-1', closed[0].clientId);
+};
+
+exports.testDripStopsWhenClientDisconnects = function () {
+    sent = [];
+    closed = [];
+    openResponses = [true, true, false];
+
+    var task = require('./sse-drip');
+    task.run({clientId: 'client-2', descriptionPrefix: 'sse-demo-'});
+
+    t.assertEquals(2, sent.length);
+    t.assertEquals(1, closed.length);
+    t.assertEquals('client-2', closed[0].clientId);
+};


### PR DESCRIPTION
Redesigns the two deprecated `task.executeFunction` call sites as named tasks, so they run on GraalJS — where `executeFunction` fails fast, because a JS closure cannot leave the context that created it.

## Sites

**Task demo — `services/task/task.ts`**
Route taken: converted to a named task (the only route the issue offers here). Added `tasks/progress-demo` (descriptor + `run(config, taskId)`) that does the stepping and calls `taskLib.progress(...)`; the service now `submitTask`s it and returns the id. The step list is static demo data, so it moved into the task and no config is needed. The old closure read `taskLib.get(taskId)` from an enclosing variable — the named task instead reads its own id from the second argument XP passes to `run` (`NamedTaskScript` calls `executeMethod(script, "run", config, id)`), so nothing is captured.

**SSE demo — `lib/sse.ts`**
Added `tasks/sse-drip` taking `{clientId, descriptionPrefix}` as config. `handleEvent` still sends the initial `Hello!`, then submits the task instead of running a closure on another thread. `lib/xp/sse` is host-backed, so `send` / `isOpen` / `close` work from the task's own context; only the closure capture had to go. The shared `lib/sse` path feeds both the `sse` and `sse-mapping` demos, and both are covered by the new tests. `cron-sse` was left untouched — it never used `executeFunction`.

Task config passes through as a `PropertyTree` with no form-schema validation (`SubmitTaskHandler` builds it straight from the config map), so the descriptors keep `form: [ ]`.

## Tests — both engines

Added a `testGraalJs` task (per enonic/lib-sql#154) wired into `check`, plus four `ScriptRunnerSupport` specs:

- `ProgressDemoTaskTest` / `SseDripTaskTest` invoke the redesigned `run` bodies directly (host libs mocked), asserting the progress sequence, the drip loop including the `isOpen` short-circuit when a client disconnects, and that the task id arrives as the `run` argument rather than a captured variable.
- `TaskServiceTest` / `SseLibTest` assert the controllers now `submitTask` the right descriptor and config, with no `executeFunction`.

Verified locally against a `publishToMavenLocal` build of enonic/xp#12198 (branch `claude/graaljs-support-limitations-pzu6z8`) under GraalVM CE 25:

```
test         12 tests, 0 failed   (Nashorn)
testGraalJs  12 tests, 0 failed   (GraalJS)
```

## Not verified end-to-end

These are async paths, so the unit tests prove limited ground: they exercise the real `run` logic, but with `/lib/xp/task` and `/lib/xp/sse` mocked. The full live path — submit → task manager → separate thread → live SSE stream to a browser — was **not** exercised in a running server. The named-task dispatch itself (`executeMethod` resolving the tsup-compiled `exports.run`) is the same mechanism this app's existing compiled services and SSE controllers already rely on in production, and the compiled descriptors (`.yaml` + `.js`) package correctly under `tasks/`.

## Draft

`testGraalJs` stays **red on CI** until enonic/xp#12198 is merged and a fresh `8.1.0-SNAPSHOT` is published: the snapshot currently on `repo.enonic.com/dev` still carries the old `ScriptRunnerSupport`, which closes the script executor during JS test discovery and so fails every GraalJS spec regardless of this app's code.

Fixes #288

<sub>*Drafted with AI assistance*</sub>
